### PR TITLE
[libra-dev] Deserialize signed transaction from bytes

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,11 @@
 set -euo pipefail
 
 # Create C to Rust bindings
-#bindgen libra-dev/include/data.h --whitelist-type=CEventHandle --whitelist-type=CDevAccountResource -o libra-dev/src/data.rs
+#bindgen libra-dev/include/data.h \
+#  --whitelist-type=CEventHandle --whitelist-type=CDevAccountResource \
+#  --whitelist-type=CDevP2PTransferTransactionArgument --whitelist-type=CDevTransactionPayload --whitelist-type=CDevRawTransaction --whitelist-type=CDevSignedTransaction \
+#  --whitelist-type=TransactionType \
+#  -o libra-dev/src/data.rs
 
 # Build libra-dev first
 cd libra-dev

--- a/libra-dev/include/data.h
+++ b/libra-dev/include/data.h
@@ -25,6 +25,35 @@ struct CDevAccountResource {
     struct CEventHandle received_events;
 };
 
+struct CDevP2PTransferTransactionArgument {
+    uint64_t value;
+    uint8_t address[32];
+};
+
+enum TransactionType {
+    PeerToPeer = 0,
+};
+
+struct CDevTransactionPayload {
+    enum TransactionType txn_type;
+    struct CDevP2PTransferTransactionArgument args; //
+};
+
+struct CDevRawTransaction {
+    uint8_t sender[32];
+    uint64_t sequence_number;
+    struct CDevTransactionPayload payload;
+    uint64_t max_gas_amount;
+    uint64_t gas_unit_price;
+    uint64_t expiration_time_secs;
+};
+
+struct CDevSignedTransaction {
+    struct CDevRawTransaction raw_txn;
+    uint8_t public_key[32];
+    uint8_t signature[64];
+};
+
 struct CDevAccountResource account_resource_from_lcs(const uint8_t *buf, size_t len);
 void account_resource_free(struct CDevAccountResource *point);
 /*!
@@ -33,12 +62,13 @@ void account_resource_free(struct CDevAccountResource *point);
  * @param[out] buf is the pointer that will be filled with the memory address of the transaction allocated in rust. User takes ownership of pointer returned by *buf, which needs to be freed using libra_signed_transcation_free
  * @param[out] len is the length of the signed transaction memory buffer.
 */
-void libra_signed_transaction_build(const uint8_t sender[32], const uint8_t receiver[32], uint64_t sequence, uint64_t num_coins, uint64_t max_gas_amount, uint64_t gas_unit_price, uint64_t expiration_time_millis, const uint8_t* private_key_bytes, uint8_t** buf, size_t* len);
+void libra_signed_transaction_build(const uint8_t sender[32], const uint8_t receiver[32], uint64_t sequence, uint64_t num_coins, uint64_t max_gas_amount, uint64_t gas_unit_price, uint64_t expiration_time_secs, const uint8_t* private_key_bytes, uint8_t** buf, size_t* len);
 /*!
  * Function to free the allocation memory in rust for transaction
  * @param buf is the pointer to the memory address of the transaction allocated in rust, and needs to be freed from client side
  */
 void libra_signed_transaction_free(uint8_t** buf);
+struct CDevSignedTransaction libra_signed_transaction_deserialize(const uint8_t *buf, size_t len);
 
 #ifdef __cplusplus
 };

--- a/libra-dev/src/account_resource.rs
+++ b/libra-dev/src/account_resource.rs
@@ -8,8 +8,11 @@ use libra_types::{
 use std::slice;
 
 #[no_mangle]
-pub extern "C" fn account_resource_from_lcs(buf: *const u8, len: usize) -> CDevAccountResource {
-    let buf: &[u8] = unsafe { slice::from_raw_parts(buf, len) };
+pub unsafe extern "C" fn account_resource_from_lcs(
+    buf: *const u8,
+    len: usize,
+) -> CDevAccountResource {
+    let buf: &[u8] = slice::from_raw_parts(buf, len);
 
     let account_state_blob = AccountStateBlob::from(buf.to_vec());
     let account_resource =

--- a/libra-dev/src/data.rs
+++ b/libra-dev/src/data.rs
@@ -143,3 +143,235 @@ fn bindgen_test_layout_CDevAccountResource() {
         )
     );
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct CDevP2PTransferTransactionArgument {
+    pub value: u64,
+    pub address: [u8; 32usize],
+}
+#[test]
+fn bindgen_test_layout_CDevP2PTransferTransactionArgument() {
+    assert_eq!(
+        ::std::mem::size_of::<CDevP2PTransferTransactionArgument>(),
+        40usize,
+        concat!("Size of: ", stringify!(CDevP2PTransferTransactionArgument))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<CDevP2PTransferTransactionArgument>(),
+        8usize,
+        concat!(
+            "Alignment of ",
+            stringify!(CDevP2PTransferTransactionArgument)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<CDevP2PTransferTransactionArgument>())).value as *const _
+                as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(CDevP2PTransferTransactionArgument),
+            "::",
+            stringify!(value)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<CDevP2PTransferTransactionArgument>())).address as *const _
+                as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(CDevP2PTransferTransactionArgument),
+            "::",
+            stringify!(address)
+        )
+    );
+}
+pub const TransactionType_PeerToPeer: TransactionType = 0;
+pub type TransactionType = u32;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct CDevTransactionPayload {
+    pub txn_type: TransactionType,
+    pub args: CDevP2PTransferTransactionArgument,
+}
+#[test]
+fn bindgen_test_layout_CDevTransactionPayload() {
+    assert_eq!(
+        ::std::mem::size_of::<CDevTransactionPayload>(),
+        48usize,
+        concat!("Size of: ", stringify!(CDevTransactionPayload))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<CDevTransactionPayload>(),
+        8usize,
+        concat!("Alignment of ", stringify!(CDevTransactionPayload))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<CDevTransactionPayload>())).txn_type as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(CDevTransactionPayload),
+            "::",
+            stringify!(txn_type)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<CDevTransactionPayload>())).args as *const _ as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(CDevTransactionPayload),
+            "::",
+            stringify!(args)
+        )
+    );
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct CDevRawTransaction {
+    pub sender: [u8; 32usize],
+    pub sequence_number: u64,
+    pub payload: CDevTransactionPayload,
+    pub max_gas_amount: u64,
+    pub gas_unit_price: u64,
+    pub expiration_time_secs: u64,
+}
+#[test]
+fn bindgen_test_layout_CDevRawTransaction() {
+    assert_eq!(
+        ::std::mem::size_of::<CDevRawTransaction>(),
+        112usize,
+        concat!("Size of: ", stringify!(CDevRawTransaction))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<CDevRawTransaction>(),
+        8usize,
+        concat!("Alignment of ", stringify!(CDevRawTransaction))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<CDevRawTransaction>())).sender as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(CDevRawTransaction),
+            "::",
+            stringify!(sender)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<CDevRawTransaction>())).sequence_number as *const _ as usize
+        },
+        32usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(CDevRawTransaction),
+            "::",
+            stringify!(sequence_number)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<CDevRawTransaction>())).payload as *const _ as usize },
+        40usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(CDevRawTransaction),
+            "::",
+            stringify!(payload)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<CDevRawTransaction>())).max_gas_amount as *const _ as usize
+        },
+        88usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(CDevRawTransaction),
+            "::",
+            stringify!(max_gas_amount)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<CDevRawTransaction>())).gas_unit_price as *const _ as usize
+        },
+        96usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(CDevRawTransaction),
+            "::",
+            stringify!(gas_unit_price)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<CDevRawTransaction>())).expiration_time_secs as *const _ as usize
+        },
+        104usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(CDevRawTransaction),
+            "::",
+            stringify!(expiration_time_secs)
+        )
+    );
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct CDevSignedTransaction {
+    pub raw_txn: CDevRawTransaction,
+    pub public_key: [u8; 32usize],
+    pub signature: [u8; 64usize],
+}
+#[test]
+fn bindgen_test_layout_CDevSignedTransaction() {
+    assert_eq!(
+        ::std::mem::size_of::<CDevSignedTransaction>(),
+        208usize,
+        concat!("Size of: ", stringify!(CDevSignedTransaction))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<CDevSignedTransaction>(),
+        8usize,
+        concat!("Alignment of ", stringify!(CDevSignedTransaction))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<CDevSignedTransaction>())).raw_txn as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(CDevSignedTransaction),
+            "::",
+            stringify!(raw_txn)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<CDevSignedTransaction>())).public_key as *const _ as usize
+        },
+        112usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(CDevSignedTransaction),
+            "::",
+            stringify!(public_key)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<CDevSignedTransaction>())).signature as *const _ as usize },
+        144usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(CDevSignedTransaction),
+            "::",
+            stringify!(signature)
+        )
+    );
+}


### PR DESCRIPTION
WIP

This PR deserializes a signed transaction in bytes into a CDevSignedTransaction type. A things to figure out: 
1) [RESOLVED - use secs not millis] millis from duration comes in u128 but C does not support u128. Is there a way to convert it safely? 
2) [RESOLVED - use enums to indicate transaction type] CODE in transaction payload is a ByteArray, which means we need client to pass in a pointer and free it after. Is it worth doing that or should we just return transaction type since we'll only support transfer type for now?