### PR TITLE
[events] Deserialize event type

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,6 +9,7 @@ bindgen libra-dev/include/data.h \
   --whitelist-type=LibraP2PTransferTransactionArgument --whitelist-type=LibraTransactionPayload --whitelist-type=LibraRawTransaction --whitelist-type=LibraSignedTransaction \
   --whitelist-type=TransactionType \
   --whitelist-type=LibraAccountKey \
+  --whitelist-type=LibraEvent --whitelist-type=LibraPaymentEvent --whitelist-type=LibraEventType \
   -o libra-dev/src/data.rs
 
 # Build libra-dev first

--- a/libra-dev/include/data.h
+++ b/libra-dev/include/data.h
@@ -68,6 +68,24 @@ struct LibraAccountKey {
     uint8_t public_key[32];
 };
 
+enum LibraEventType {
+    SentPaymentEvent = 1,
+    ReceivedPaymentEvent = 2,
+    UndefinedEvent = -1,
+};
+
+struct LibraPaymentEvent {
+    uint8_t sender_address[32];
+    uint8_t receiver_address[32];
+    uint64_t amount;
+    uint8_t module[255];
+};
+
+struct LibraEvent {
+    enum LibraEventType event_type;
+    struct LibraPaymentEvent payment_event;
+};
+
 /*!
  * Decode LibraAccountResource from bytes in AccountStateBlob.
  *
@@ -126,6 +144,14 @@ enum LibraStatus libra_RawTransactionBytes_from(const uint8_t sender[32], const 
 enum LibraStatus libra_RawTransaction_sign(const uint8_t *buf_raw_txn, size_t len_raw_txn, const uint8_t *buf_public_key, size_t len_public_key, const uint8_t *buf_signature, size_t len_signature, uint8_t** buf_result, size_t* len_result);
 
 enum LibraStatus libra_LibraAccount_from(const uint8_t private_key_bytes[32], struct LibraAccountKey *out);
+
+/*!
+ * This function takes in an event key, event data and event type tag in bytes, and return LibraEvent.
+ * To get the event in a memory safe manner, the client needs to call free on the output with `libra_event_free`.
+ * @param[out] caller allocated LibraEvent to write into.
+ * @returns status code, one of LibraStatus
+*/
+enum LibraStatus libra_LibraEvent_from(const uint8_t *buf_key, size_t len_key, const uint8_t *buf_data, size_t len_data, const uint8_t *buf_type_tag, size_t len_type_tag, struct LibraEvent *out);
 
 #ifdef __cplusplus
 };

--- a/libra-dev/src/data.rs
+++ b/libra-dev/src/data.rs
@@ -467,3 +467,124 @@ fn bindgen_test_layout_LibraAccountKey() {
         )
     );
 }
+#[repr(i32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum LibraEventType {
+    SentPaymentEvent = 1,
+    ReceivedPaymentEvent = 2,
+    UndefinedEvent = -1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct LibraPaymentEvent {
+    pub sender_address: [u8; 32usize],
+    pub receiver_address: [u8; 32usize],
+    pub amount: u64,
+    pub module: [u8; 255usize],
+}
+#[test]
+fn bindgen_test_layout_LibraPaymentEvent() {
+    assert_eq!(
+        ::std::mem::size_of::<LibraPaymentEvent>(),
+        328usize,
+        concat!("Size of: ", stringify!(LibraPaymentEvent))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<LibraPaymentEvent>(),
+        8usize,
+        concat!("Alignment of ", stringify!(LibraPaymentEvent))
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<LibraPaymentEvent>())).sender_address as *const _ as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(LibraPaymentEvent),
+            "::",
+            stringify!(sender_address)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<LibraPaymentEvent>())).receiver_address as *const _ as usize
+        },
+        32usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(LibraPaymentEvent),
+            "::",
+            stringify!(receiver_address)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<LibraPaymentEvent>())).amount as *const _ as usize },
+        64usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(LibraPaymentEvent),
+            "::",
+            stringify!(amount)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<LibraPaymentEvent>())).module as *const _ as usize },
+        72usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(LibraPaymentEvent),
+            "::",
+            stringify!(module)
+        )
+    );
+}
+impl Default for LibraPaymentEvent {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct LibraEvent {
+    pub event_type: LibraEventType,
+    pub payment_event: LibraPaymentEvent,
+}
+#[test]
+fn bindgen_test_layout_LibraEvent() {
+    assert_eq!(
+        ::std::mem::size_of::<LibraEvent>(),
+        336usize,
+        concat!("Size of: ", stringify!(LibraEvent))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<LibraEvent>(),
+        8usize,
+        concat!("Alignment of ", stringify!(LibraEvent))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<LibraEvent>())).event_type as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(LibraEvent),
+            "::",
+            stringify!(event_type)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<LibraEvent>())).payment_event as *const _ as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(LibraEvent),
+            "::",
+            stringify!(payment_event)
+        )
+    );
+}
+impl Default for LibraEvent {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}

--- a/libra-dev/src/event.rs
+++ b/libra-dev/src/event.rs
@@ -1,0 +1,175 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::data::{LibraEvent, LibraEventType, LibraPaymentEvent, LibraStatus};
+use libra_types::{
+    account_address::ADDRESS_LENGTH, account_config::AccountEvent, event::EVENT_KEY_LENGTH,
+    language_storage::TypeTag,
+};
+use std::ffi::CString;
+use std::slice;
+
+#[no_mangle]
+pub unsafe extern "C" fn libra_LibraEvent_from(
+    buf_key: *const u8,
+    len_key: usize,
+    buf_data: *const u8,
+    len_data: usize,
+    buf_type_tag: *const u8,
+    len_type_tag: usize,
+    out: *mut LibraEvent,
+) -> LibraStatus {
+    let buffer_key: &[u8] = slice::from_raw_parts(buf_key, len_key);
+    let buffer_data: &[u8] = slice::from_raw_parts(buf_data, len_data);
+    let buffer_type_tag: &[u8] = slice::from_raw_parts(buf_type_tag, len_type_tag);
+
+    let mut key = [0u8; EVENT_KEY_LENGTH];
+    key.copy_from_slice(buffer_key);
+
+    let (_salt, event_address) = buffer_key.split_at(8);
+    let mut key_address = [0u8; ADDRESS_LENGTH];
+    key_address.copy_from_slice(event_address);
+
+    let account_event: AccountEvent = match AccountEvent::try_from(buffer_data) {
+        Ok(result) => result,
+        Err(_e) => {
+            return LibraStatus::InvalidArgument;
+        }
+    };
+
+    let mut receiver_account = [0u8; ADDRESS_LENGTH];
+    receiver_account.copy_from_slice(account_event.account().as_ref());
+
+    let type_tag: TypeTag = match lcs::from_bytes(buffer_type_tag) {
+        Ok(result) => result,
+        Err(_e) => {
+            return LibraStatus::InvalidArgument;
+        }
+    };
+
+    let mut module = None;
+    let mut name = None;
+    if let TypeTag::Struct(struct_tag) = type_tag {
+        module = Some(struct_tag.module.into_string());
+        name = Some(struct_tag.name.into_string());
+    };
+
+    let module = match module {
+        Some(result) => result,
+        None => {
+            return LibraStatus::InvalidArgument;
+        }
+    };
+    let module_tmp = match CString::new(module) {
+        Ok(result) => result,
+        Err(_e) => {
+            return LibraStatus::InvalidArgument;
+        }
+    };
+
+    let mut event_enum = None;
+    if let Some(event_type) = name {
+        match event_type.as_str() {
+            "SentPaymentEvent" => {
+                event_enum = Some(LibraEventType::SentPaymentEvent);
+            }
+            "ReceivedPaymentEvent" => {
+                event_enum = Some(LibraEventType::ReceivedPaymentEvent);
+            }
+            _ => {
+                event_enum = Some(LibraEventType::UndefinedEvent);
+            }
+        };
+    };
+    let event_enum = match event_enum {
+        Some(result) => result,
+        None => {
+            return LibraStatus::InvalidArgument;
+        }
+    };
+
+    let module_bytes = module_tmp.as_bytes_with_nul();
+    let module_len = module_bytes.len();
+    let mut module = [0u8; 255];
+    module[..module_len].copy_from_slice(module_bytes);
+
+    let event_data = LibraPaymentEvent {
+        sender_address: key_address,
+        receiver_address: receiver_account,
+        amount: account_event.amount(),
+        module,
+    };
+
+    *out = LibraEvent {
+        event_type: event_enum,
+        payment_event: event_data,
+    };
+
+    LibraStatus::OK
+}
+
+#[test]
+fn test_libra_LibraEvent_from() {
+    use libra_crypto::ed25519::compat;
+    use libra_types::{
+        account_address::AccountAddress,
+        contract_event::ContractEvent,
+        event::{EventHandle, EventKey},
+        identifier::Identifier,
+        language_storage::{StructTag, TypeTag::Struct},
+    };
+    use std::ffi::CStr;
+
+    let keypair = compat::generate_keypair(None);
+    let public_key = keypair.1;
+    let sender_address = AccountAddress::from_public_key(&public_key);
+    let sent_event_handle = EventHandle::new(EventKey::new_from_address(&sender_address, 0), 0);
+    let sequence_number = sent_event_handle.count();
+    let event_key = sent_event_handle.key();
+    let module = "LibraAccount";
+
+    let type_tag = Struct(StructTag {
+        address: AccountAddress::new([0; 32]),
+        module: Identifier::new(module).unwrap(),
+        name: Identifier::new("SentPaymentEvent").unwrap(),
+        type_params: [].to_vec(),
+    });
+    let amount = 50000000;
+    let receiver_address = AccountAddress::random();
+    let event_data = AccountEvent::new(amount, receiver_address, vec![]);
+    let event_data_bytes = lcs::to_bytes(&event_data).unwrap();
+    let event = ContractEvent::new(*event_key, sequence_number, type_tag, event_data_bytes);
+
+    let proto_txn = libra_types::proto::types::Event::from(event.clone());
+
+    let mut libra_event = LibraEvent::default();
+    let result = unsafe {
+        libra_LibraEvent_from(
+            proto_txn.key.as_ptr(),
+            proto_txn.key.len(),
+            proto_txn.event_data.as_ptr(),
+            proto_txn.event_data.len(),
+            proto_txn.type_tag.as_ptr(),
+            proto_txn.type_tag.len(),
+            &mut libra_event,
+        )
+    };
+    assert_eq!(result, LibraStatus::OK);
+
+    assert_eq!(
+        sender_address,
+        AccountAddress::new(libra_event.payment_event.sender_address)
+    );
+    assert_eq!(
+        receiver_address,
+        AccountAddress::new(libra_event.payment_event.receiver_address),
+    );
+    assert_eq!(amount, libra_event.payment_event.amount);
+
+    let module_c_string: &CStr =
+        unsafe { CStr::from_ptr(libra_event.payment_event.module.as_ptr() as *const i8) };
+    let module_str_slice: &str = module_c_string.to_str().unwrap();
+
+    assert_eq!(module_str_slice, module);
+    assert_eq!(libra_event.event_type, LibraEventType::SentPaymentEvent);
+}

--- a/libra-dev/src/lib.rs
+++ b/libra-dev/src/lib.rs
@@ -8,4 +8,5 @@ mod data;
 
 pub mod account;
 pub mod account_resource;
+pub mod event;
 pub mod transaction;

--- a/libra-dev/src/transaction.rs
+++ b/libra-dev/src/transaction.rs
@@ -461,7 +461,7 @@ fn test_libra_raw_transaction_bytes_from() {
     };
 }
 
-/// Generate an Signed Transaction and deserialize
+/// Generate a Signed Transaction and deserialize
 #[test]
 fn test_libra_signed_transaction_deserialize() {
     let keypair = compat::generate_keypair(None);


### PR DESCRIPTION
This PR defines the Event types and provides a function to deserialize events. 

Still a few things to figure out: 
- [done] Need to create AccountEvent in order to get event data
- [done] Need to connect to updated testnet to get updated EventKey definition and fetch address from EventKey