### PR TITLE
[libra-dev][transaction] Craft raw transaction and sign transaction

### DIFF
--- a/libra-dev/include/data.h
+++ b/libra-dev/include/data.h
@@ -64,7 +64,7 @@ struct LibraSignedTransaction {
  * Decode LibraAccountResource from bytes in AccountStateBlob.
  *
  * @param[in] buf contains encoded bytes of AccountStateBlob
- * @param[in] len is the length of the signed transaction memory buffer.
+ * @param[in] len is the length of the signed AccountStateBlob memory buffer.
  * @param[out] caller allocated LibraAccountResource to write into.
  *
  * @returns status code, one of LibraAPIStatus
@@ -72,18 +72,50 @@ struct LibraSignedTransaction {
 enum LibraStatus libra_LibraAccountResource_from(const uint8_t *buf, size_t len, struct LibraAccountResource *out);
 
 /*!
+ *  Get serialized signed transaction from a list of transaction parameters
+ *
  * To get the serialized transaction in a memory safe manner, the client needs to pass in a pointer to a pointer to the allocated memory in rust
- * and call free on the memory address with `libra_SignedTransactionBytes_free`.
+ * and call free on the memory address with `libra_free_bytes_buffer`.
  * @param[out] buf is the pointer that will be filled with the memory address of the transaction allocated in rust. User takes ownership of pointer returned by *buf, which needs to be freed using libra_signed_transcation_free
  * @param[out] len is the length of the signed transaction memory buffer.
 */
 enum LibraStatus libra_SignedTransactionBytes_from(const uint8_t sender[32], const uint8_t receiver[32], uint64_t sequence, uint64_t num_coins, uint64_t max_gas_amount, uint64_t gas_unit_price, uint64_t expiration_time_secs, const uint8_t* private_key_bytes, uint8_t** ptr_buf, size_t* ptr_len);
+
 /*!
- * Function to free the allocation memory in rust for transaction
- * @param buf is the pointer to the transaction allocated in rust, and needs to be freed from client side
+ * Function to free the allocation memory in rust for bytes
+ * @param buf is the pointer to the bytes allocated in rust, and needs to be freed from client side
  */
-void libra_SignedTransactionBytes_free(const uint8_t* buf);
+void libra_free_bytes_buffer(const uint8_t* buf);
+
+/*!
+ * Decode LibraSignedTransaction from bytes in SignedTransaction proto.
+ *
+ * @param[in] buf contains encoded bytes of txn_bytes
+ * @param[in] len is the length of the signed transaction memory buffer.
+ * @param[out] caller allocated LibraSignedTransaction to write into.
+ *
+ * @returns status code, one of LibraAPIStatus
+*/
 enum LibraStatus libra_LibraSignedTransaction_from(const uint8_t *buf, size_t len, struct LibraSignedTransaction *out);
+
+/*!
+ * Get serialized raw transaction from a list of transaction parameters
+ *
+ * To get the serialized raw transaction in a memory safe manner, the client needs to pass in a pointer to a pointer to the allocated memory in rust
+ * and call free on the memory address with `libra_free_bytes_buffer`.
+ * @param[out] buf is the pointer that will be filled with the memory address of the transaction allocated in rust. User takes ownership of pointer returned by *buf, which needs to be freed using libra_free_bytes_buffer
+ * @param[out] len is the length of the raw transaction memory buffer.
+*/
+enum LibraStatus libra_RawTransactionBytes_from(const uint8_t sender[32], const uint8_t receiver[32], uint64_t sequence, uint64_t num_coins, uint64_t max_gas_amount, uint64_t gas_unit_price, uint64_t expiration_time_secs, uint8_t** buf, size_t* len);
+
+/*!
+ * This function takes in a raw transaction, public key and signature in bytes, and return a signed transaction in bytes.
+ * To get the serialized signed transaction in a memory safe manner, the client needs to pass in a pointer to a pointer to the allocated memory in rust
+ * and call free on the memory address with `libra_free_bytes_buffer`.
+ * @param[out] buf_result is the pointer that will be filled with the memory address of the transaction allocated in rust. User takes ownership of pointer returned by *buf, which needs to be freed using libra_free_bytes_buffer
+ * @param[out] len_result is the length of the signed transaction memory buffer.
+*/
+enum LibraStatus libra_RawTransaction_sign(const uint8_t *buf_raw_txn, size_t len_raw_txn, const uint8_t *buf_public_key, size_t len_public_key, const uint8_t *buf_signature, size_t len_signature, uint8_t** buf_result, size_t* len_result);
 
 #ifdef __cplusplus
 };

--- a/libra-dev/src/transaction.rs
+++ b/libra-dev/src/transaction.rs
@@ -93,10 +93,118 @@ pub unsafe extern "C" fn libra_SignedTransactionBytes_from(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn libra_SignedTransactionBytes_free(buf: *const u8) {
+pub unsafe extern "C" fn libra_free_bytes_buffer(buf: *const u8) {
     if !buf.is_null() {
         libc::free(buf as *mut libc::c_void);
     }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn libra_RawTransactionBytes_from(
+    sender: *const u8,
+    receiver: *const u8,
+    sequence: u64,
+    num_coins: u64,
+    max_gas_amount: u64,
+    gas_unit_price: u64,
+    expiration_time_secs: u64,
+    buf: *mut *mut u8,
+    len: *mut usize,
+) -> LibraStatus {
+    let sender_buf = slice::from_raw_parts(sender, ADDRESS_LENGTH);
+    let sender_address = match AccountAddress::try_from(sender_buf) {
+        Ok(result) => result,
+        Err(_e) => {
+            return LibraStatus::InvalidArgument;
+        }
+    };
+
+    let receiver_buf = slice::from_raw_parts(receiver, ADDRESS_LENGTH);
+    let receiver_address = match AccountAddress::try_from(receiver_buf) {
+        Ok(result) => result,
+        Err(_e) => {
+            return LibraStatus::InvalidArgument;
+        }
+    };
+    let expiration_time = Duration::from_secs(expiration_time_secs);
+
+    let program = encode_transfer_script(&receiver_address, num_coins);
+    let payload = TransactionPayload::Script(program);
+    let raw_txn = RawTransaction::new(
+        sender_address,
+        sequence,
+        payload,
+        max_gas_amount,
+        gas_unit_price,
+        expiration_time,
+    );
+
+    let raw_txn_bytes = match to_bytes(&raw_txn) {
+        Ok(result) => result,
+        Err(_e) => {
+            return LibraStatus::InternalError;
+        }
+    };
+
+    let txn_buf: (*mut u8) = libc::malloc(raw_txn_bytes.len()).cast();
+    txn_buf.copy_from(raw_txn_bytes.as_ptr(), raw_txn_bytes.len());
+
+    *buf = txn_buf;
+    *len = raw_txn_bytes.len();
+
+    LibraStatus::OK
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn libra_RawTransaction_sign(
+    buf_raw_txn: *const u8,
+    len_raw_txn: usize,
+    buf_public_key: *const u8,
+    len_public_key: usize,
+    buf_signature: *const u8,
+    len_signature: usize,
+    buf_result: *mut *mut u8,
+    len_result: *mut usize,
+) -> LibraStatus {
+    let raw_txn_bytes: &[u8] = slice::from_raw_parts(buf_raw_txn, len_raw_txn);
+    let raw_txn: RawTransaction = match lcs::from_bytes(&raw_txn_bytes) {
+        Ok(result) => result,
+        Err(_e) => {
+            return LibraStatus::InvalidArgument;
+        }
+    };
+
+    let public_key_bytes: &[u8] = slice::from_raw_parts(buf_public_key, len_public_key);
+    let public_key = match Ed25519PublicKey::try_from(public_key_bytes) {
+        Ok(result) => result,
+        Err(_e) => {
+            return LibraStatus::InvalidArgument;
+        }
+    };
+
+    let signature_bytes: &[u8] = slice::from_raw_parts(buf_signature, len_signature);
+    let signature = match Ed25519Signature::try_from(signature_bytes) {
+        Ok(result) => result,
+        Err(_e) => {
+            return LibraStatus::InvalidArgument;
+        }
+    };
+
+    let signed_txn = SignedTransaction::new(raw_txn, public_key, signature);
+    let signed_txn_bytes = match to_bytes(&signed_txn) {
+        Ok(result) => result,
+        Err(_e) => {
+            return LibraStatus::InternalError;
+        }
+    };
+
+    let txn_buf: (*mut u8) = libc::malloc(signed_txn_bytes.len()).cast();
+    txn_buf.copy_from(signed_txn_bytes.as_ptr(), signed_txn_bytes.len());
+
+    *buf_result = txn_buf;
+    *len_result = signed_txn_bytes.len();
+
+    LibraStatus::OK
 }
 
 #[no_mangle]
@@ -232,12 +340,101 @@ fn test_lcs_signed_transaction() {
             assert_eq!(val, amount);
         }
     }
+    assert_eq!(deserialized_signed_txn.sender(), sender_address);
     assert_eq!(deserialized_signed_txn.sequence_number(), 0);
     assert_eq!(deserialized_signed_txn.gas_unit_price(), gas_unit_price);
     assert_eq!(deserialized_signed_txn.public_key(), public_key);
     assert!(deserialized_signed_txn.check_signature().is_ok());
 
-    unsafe { libra_SignedTransactionBytes_free(buf_ptr) };
+    unsafe { libra_free_bytes_buffer(buf_ptr) };
+}
+
+/// Generate an Signed Transaction and deserialize
+#[test]
+fn test_libra_raw_transaction_bytes_from() {
+    use lcs::from_bytes;
+    use libra_crypto::{hash::CryptoHash, test_utils::TEST_SEED, traits::SigningKey};
+    use libra_types::transaction::{SignedTransaction, TransactionArgument};
+    use rand::{rngs::StdRng, SeedableRng};
+
+    // generate key pair
+    let mut rng = StdRng::from_seed(TEST_SEED);
+    let key_pair = compat::generate_keypair(&mut rng);
+    let private_key = key_pair.0;
+    let public_key = key_pair.1;
+
+    // create transfer parameters
+    let sender_address = AccountAddress::from_public_key(&public_key);
+    let receiver_address = AccountAddress::random();
+    let sequence = 0;
+    let amount = 100000000;
+    let gas_unit_price = 123;
+    let max_gas_amount = 1000;
+    let expiration_time_secs = 0;
+
+    // get raw transaction in bytes
+    let mut buf: u8 = 0;
+    let mut buf_ptr: *mut u8 = &mut buf;
+    let mut len: usize = 0;
+    unsafe {
+        libra_RawTransactionBytes_from(
+            sender_address.as_ref().as_ptr(),
+            receiver_address.as_ref().as_ptr(),
+            sequence,
+            amount,
+            max_gas_amount,
+            gas_unit_price,
+            expiration_time_secs,
+            &mut buf_ptr,
+            &mut len,
+        )
+    };
+
+    // deserialize raw txn and sign
+    let raw_txn_bytes: &[u8] = unsafe { slice::from_raw_parts(buf_ptr, len) };
+    let deserialized_raw_txn: RawTransaction =
+        from_bytes(raw_txn_bytes).expect("LCS deserialization failed for raw transaction");
+    let signature = private_key.sign_message(&deserialized_raw_txn.hash());
+
+    // get signed transaction by signing raw transaction
+    let mut signed_txn_buf: u8 = 0;
+    let mut signed_txn_buf_ptr: *mut u8 = &mut signed_txn_buf;
+    let mut signed_txn_len: usize = 0;
+    unsafe {
+        libra_RawTransaction_sign(
+            raw_txn_bytes.as_ptr(),
+            raw_txn_bytes.len(),
+            public_key.to_bytes().as_ptr(),
+            public_key.to_bytes().len(),
+            signature.to_bytes().as_ptr(),
+            signature.to_bytes().len(),
+            &mut signed_txn_buf_ptr,
+            &mut signed_txn_len,
+        )
+    };
+
+    let signed_txn_bytes: &[u8] =
+        unsafe { slice::from_raw_parts(signed_txn_buf_ptr, signed_txn_len) };
+    let deserialized_signed_txn: SignedTransaction =
+        from_bytes(signed_txn_bytes).expect("LCS deserialization failed for signed transaction");
+
+    // test values equal
+    if let TransactionPayload::Script(program) = deserialized_signed_txn.payload() {
+        if let TransactionArgument::U64(val) = program.args()[1] {
+            assert_eq!(val, amount);
+        }
+    }
+    assert_eq!(deserialized_signed_txn.sender(), sender_address);
+    assert_eq!(deserialized_signed_txn.sequence_number(), 0);
+    assert_eq!(deserialized_signed_txn.gas_unit_price(), gas_unit_price);
+    assert_eq!(deserialized_signed_txn.public_key(), public_key);
+    assert!(deserialized_signed_txn.check_signature().is_ok());
+
+    // free memory
+    unsafe {
+        libra_free_bytes_buffer(buf_ptr);
+        libra_free_bytes_buffer(signed_txn_buf_ptr);
+    };
 }
 
 /// Generate an Signed Transaction and deserialize


### PR DESCRIPTION
Custody needs the use case of 1) crafting a raw transaction and getting bytes and 2) getting signed transaction in bytes after signing the raw transaction.

We already have the function to return a signed transaction, but since there are cases when client cannot pass in the private key or would want to sign the transaction themselves, we provide these functionalities