### PR TITLE
[libra-dev][transaction] Rename to correct naming convention

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,11 +2,11 @@
 set -euo pipefail
 
 # Create C to Rust bindings
-#bindgen libra-dev/include/data.h \
-#  --whitelist-type=CEventHandle --whitelist-type=CDevAccountResource \
-#  --whitelist-type=CDevP2PTransferTransactionArgument --whitelist-type=CDevTransactionPayload --whitelist-type=CDevRawTransaction --whitelist-type=CDevSignedTransaction \
-#  --whitelist-type=TransactionType \
-#  -o libra-dev/src/data.rs
+bindgen libra-dev/include/data.h \
+  --whitelist-type=CEventHandle --whitelist-type=CDevAccountResource \
+  --whitelist-type=LibraP2PTransferTransactionArgument --whitelist-type=LibraTransactionPayload --whitelist-type=LibraRawTransaction --whitelist-type=LibraSignedTransaction \
+  --whitelist-type=TransactionType \
+  -o libra-dev/src/data.rs
 
 # Build libra-dev first
 cd libra-dev

--- a/libra-dev/include/data.h
+++ b/libra-dev/include/data.h
@@ -25,7 +25,7 @@ struct CDevAccountResource {
     struct CEventHandle received_events;
 };
 
-struct CDevP2PTransferTransactionArgument {
+struct LibraP2PTransferTransactionArgument {
     uint64_t value;
     uint8_t address[32];
 };
@@ -34,22 +34,22 @@ enum TransactionType {
     PeerToPeer = 0,
 };
 
-struct CDevTransactionPayload {
+struct LibraTransactionPayload {
     enum TransactionType txn_type;
-    struct CDevP2PTransferTransactionArgument args; //
+    struct LibraP2PTransferTransactionArgument args; //
 };
 
-struct CDevRawTransaction {
+struct LibraRawTransaction {
     uint8_t sender[32];
     uint64_t sequence_number;
-    struct CDevTransactionPayload payload;
+    struct LibraTransactionPayload payload;
     uint64_t max_gas_amount;
     uint64_t gas_unit_price;
     uint64_t expiration_time_secs;
 };
 
-struct CDevSignedTransaction {
-    struct CDevRawTransaction raw_txn;
+struct LibraSignedTransaction {
+    struct LibraRawTransaction raw_txn;
     uint8_t public_key[32];
     uint8_t signature[64];
 };
@@ -58,17 +58,17 @@ struct CDevAccountResource account_resource_from_lcs(const uint8_t *buf, size_t 
 void account_resource_free(struct CDevAccountResource *point);
 /*!
  * To get the serialized transaction in a memory safe manner, the client needs to pass in a pointer to a pointer to the allocated memory in rust
- * and call free on the memory address with `libra_signed_transaction_free`.
+ * and call free on the memory address with `libra_SignedTransactionBytes_free`.
  * @param[out] buf is the pointer that will be filled with the memory address of the transaction allocated in rust. User takes ownership of pointer returned by *buf, which needs to be freed using libra_signed_transcation_free
  * @param[out] len is the length of the signed transaction memory buffer.
 */
-void libra_signed_transaction_build(const uint8_t sender[32], const uint8_t receiver[32], uint64_t sequence, uint64_t num_coins, uint64_t max_gas_amount, uint64_t gas_unit_price, uint64_t expiration_time_secs, const uint8_t* private_key_bytes, uint8_t** buf, size_t* len);
+void libra_SignedTransactionBytes_from(const uint8_t sender[32], const uint8_t receiver[32], uint64_t sequence, uint64_t num_coins, uint64_t max_gas_amount, uint64_t gas_unit_price, uint64_t expiration_time_secs, const uint8_t* private_key_bytes, uint8_t** ptr_buf, size_t* ptr_len);
 /*!
  * Function to free the allocation memory in rust for transaction
- * @param buf is the pointer to the memory address of the transaction allocated in rust, and needs to be freed from client side
+ * @param buf is the pointer to the transaction allocated in rust, and needs to be freed from client side
  */
-void libra_signed_transaction_free(uint8_t** buf);
-struct CDevSignedTransaction libra_signed_transaction_deserialize(const uint8_t *buf, size_t len);
+void libra_SignedTransactionBytes_free(const uint8_t* buf);
+struct LibraSignedTransaction libra_LibraSignedTransaction_from(const uint8_t *buf, size_t len);
 
 #ifdef __cplusplus
 };

--- a/libra-dev/src/data.rs
+++ b/libra-dev/src/data.rs
@@ -145,47 +145,47 @@ fn bindgen_test_layout_CDevAccountResource() {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct CDevP2PTransferTransactionArgument {
+pub struct LibraP2PTransferTransactionArgument {
     pub value: u64,
     pub address: [u8; 32usize],
 }
 #[test]
-fn bindgen_test_layout_CDevP2PTransferTransactionArgument() {
+fn bindgen_test_layout_LibraP2PTransferTransactionArgument() {
     assert_eq!(
-        ::std::mem::size_of::<CDevP2PTransferTransactionArgument>(),
+        ::std::mem::size_of::<LibraP2PTransferTransactionArgument>(),
         40usize,
-        concat!("Size of: ", stringify!(CDevP2PTransferTransactionArgument))
+        concat!("Size of: ", stringify!(LibraP2PTransferTransactionArgument))
     );
     assert_eq!(
-        ::std::mem::align_of::<CDevP2PTransferTransactionArgument>(),
+        ::std::mem::align_of::<LibraP2PTransferTransactionArgument>(),
         8usize,
         concat!(
             "Alignment of ",
-            stringify!(CDevP2PTransferTransactionArgument)
+            stringify!(LibraP2PTransferTransactionArgument)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<CDevP2PTransferTransactionArgument>())).value as *const _
+            &(*(::std::ptr::null::<LibraP2PTransferTransactionArgument>())).value as *const _
                 as usize
         },
         0usize,
         concat!(
             "Offset of field: ",
-            stringify!(CDevP2PTransferTransactionArgument),
+            stringify!(LibraP2PTransferTransactionArgument),
             "::",
             stringify!(value)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<CDevP2PTransferTransactionArgument>())).address as *const _
+            &(*(::std::ptr::null::<LibraP2PTransferTransactionArgument>())).address as *const _
                 as usize
         },
         8usize,
         concat!(
             "Offset of field: ",
-            stringify!(CDevP2PTransferTransactionArgument),
+            stringify!(LibraP2PTransferTransactionArgument),
             "::",
             stringify!(address)
         )
@@ -195,38 +195,40 @@ pub const TransactionType_PeerToPeer: TransactionType = 0;
 pub type TransactionType = u32;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct CDevTransactionPayload {
+pub struct LibraTransactionPayload {
     pub txn_type: TransactionType,
-    pub args: CDevP2PTransferTransactionArgument,
+    pub args: LibraP2PTransferTransactionArgument,
 }
 #[test]
-fn bindgen_test_layout_CDevTransactionPayload() {
+fn bindgen_test_layout_LibraTransactionPayload() {
     assert_eq!(
-        ::std::mem::size_of::<CDevTransactionPayload>(),
+        ::std::mem::size_of::<LibraTransactionPayload>(),
         48usize,
-        concat!("Size of: ", stringify!(CDevTransactionPayload))
+        concat!("Size of: ", stringify!(LibraTransactionPayload))
     );
     assert_eq!(
-        ::std::mem::align_of::<CDevTransactionPayload>(),
+        ::std::mem::align_of::<LibraTransactionPayload>(),
         8usize,
-        concat!("Alignment of ", stringify!(CDevTransactionPayload))
+        concat!("Alignment of ", stringify!(LibraTransactionPayload))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<CDevTransactionPayload>())).txn_type as *const _ as usize },
+        unsafe {
+            &(*(::std::ptr::null::<LibraTransactionPayload>())).txn_type as *const _ as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",
-            stringify!(CDevTransactionPayload),
+            stringify!(LibraTransactionPayload),
             "::",
             stringify!(txn_type)
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<CDevTransactionPayload>())).args as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<LibraTransactionPayload>())).args as *const _ as usize },
         8usize,
         concat!(
             "Offset of field: ",
-            stringify!(CDevTransactionPayload),
+            stringify!(LibraTransactionPayload),
             "::",
             stringify!(args)
         )
@@ -234,90 +236,91 @@ fn bindgen_test_layout_CDevTransactionPayload() {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct CDevRawTransaction {
+pub struct LibraRawTransaction {
     pub sender: [u8; 32usize],
     pub sequence_number: u64,
-    pub payload: CDevTransactionPayload,
+    pub payload: LibraTransactionPayload,
     pub max_gas_amount: u64,
     pub gas_unit_price: u64,
     pub expiration_time_secs: u64,
 }
 #[test]
-fn bindgen_test_layout_CDevRawTransaction() {
+fn bindgen_test_layout_LibraRawTransaction() {
     assert_eq!(
-        ::std::mem::size_of::<CDevRawTransaction>(),
+        ::std::mem::size_of::<LibraRawTransaction>(),
         112usize,
-        concat!("Size of: ", stringify!(CDevRawTransaction))
+        concat!("Size of: ", stringify!(LibraRawTransaction))
     );
     assert_eq!(
-        ::std::mem::align_of::<CDevRawTransaction>(),
+        ::std::mem::align_of::<LibraRawTransaction>(),
         8usize,
-        concat!("Alignment of ", stringify!(CDevRawTransaction))
+        concat!("Alignment of ", stringify!(LibraRawTransaction))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<CDevRawTransaction>())).sender as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<LibraRawTransaction>())).sender as *const _ as usize },
         0usize,
         concat!(
             "Offset of field: ",
-            stringify!(CDevRawTransaction),
+            stringify!(LibraRawTransaction),
             "::",
             stringify!(sender)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<CDevRawTransaction>())).sequence_number as *const _ as usize
+            &(*(::std::ptr::null::<LibraRawTransaction>())).sequence_number as *const _ as usize
         },
         32usize,
         concat!(
             "Offset of field: ",
-            stringify!(CDevRawTransaction),
+            stringify!(LibraRawTransaction),
             "::",
             stringify!(sequence_number)
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<CDevRawTransaction>())).payload as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<LibraRawTransaction>())).payload as *const _ as usize },
         40usize,
         concat!(
             "Offset of field: ",
-            stringify!(CDevRawTransaction),
+            stringify!(LibraRawTransaction),
             "::",
             stringify!(payload)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<CDevRawTransaction>())).max_gas_amount as *const _ as usize
+            &(*(::std::ptr::null::<LibraRawTransaction>())).max_gas_amount as *const _ as usize
         },
         88usize,
         concat!(
             "Offset of field: ",
-            stringify!(CDevRawTransaction),
+            stringify!(LibraRawTransaction),
             "::",
             stringify!(max_gas_amount)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<CDevRawTransaction>())).gas_unit_price as *const _ as usize
+            &(*(::std::ptr::null::<LibraRawTransaction>())).gas_unit_price as *const _ as usize
         },
         96usize,
         concat!(
             "Offset of field: ",
-            stringify!(CDevRawTransaction),
+            stringify!(LibraRawTransaction),
             "::",
             stringify!(gas_unit_price)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<CDevRawTransaction>())).expiration_time_secs as *const _ as usize
+            &(*(::std::ptr::null::<LibraRawTransaction>())).expiration_time_secs as *const _
+                as usize
         },
         104usize,
         concat!(
             "Offset of field: ",
-            stringify!(CDevRawTransaction),
+            stringify!(LibraRawTransaction),
             "::",
             stringify!(expiration_time_secs)
         )
@@ -325,51 +328,53 @@ fn bindgen_test_layout_CDevRawTransaction() {
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct CDevSignedTransaction {
-    pub raw_txn: CDevRawTransaction,
+pub struct LibraSignedTransaction {
+    pub raw_txn: LibraRawTransaction,
     pub public_key: [u8; 32usize],
     pub signature: [u8; 64usize],
 }
 #[test]
-fn bindgen_test_layout_CDevSignedTransaction() {
+fn bindgen_test_layout_LibraSignedTransaction() {
     assert_eq!(
-        ::std::mem::size_of::<CDevSignedTransaction>(),
+        ::std::mem::size_of::<LibraSignedTransaction>(),
         208usize,
-        concat!("Size of: ", stringify!(CDevSignedTransaction))
+        concat!("Size of: ", stringify!(LibraSignedTransaction))
     );
     assert_eq!(
-        ::std::mem::align_of::<CDevSignedTransaction>(),
+        ::std::mem::align_of::<LibraSignedTransaction>(),
         8usize,
-        concat!("Alignment of ", stringify!(CDevSignedTransaction))
+        concat!("Alignment of ", stringify!(LibraSignedTransaction))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<CDevSignedTransaction>())).raw_txn as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<LibraSignedTransaction>())).raw_txn as *const _ as usize },
         0usize,
         concat!(
             "Offset of field: ",
-            stringify!(CDevSignedTransaction),
+            stringify!(LibraSignedTransaction),
             "::",
             stringify!(raw_txn)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<CDevSignedTransaction>())).public_key as *const _ as usize
+            &(*(::std::ptr::null::<LibraSignedTransaction>())).public_key as *const _ as usize
         },
         112usize,
         concat!(
             "Offset of field: ",
-            stringify!(CDevSignedTransaction),
+            stringify!(LibraSignedTransaction),
             "::",
             stringify!(public_key)
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<CDevSignedTransaction>())).signature as *const _ as usize },
+        unsafe {
+            &(*(::std::ptr::null::<LibraSignedTransaction>())).signature as *const _ as usize
+        },
         144usize,
         concat!(
             "Offset of field: ",
-            stringify!(CDevSignedTransaction),
+            stringify!(LibraSignedTransaction),
             "::",
             stringify!(signature)
         )

--- a/libra-dev/src/transaction.rs
+++ b/libra-dev/src/transaction.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::data::{
-    CDevP2PTransferTransactionArgument, CDevRawTransaction, CDevSignedTransaction,
-    CDevTransactionPayload, TransactionType_PeerToPeer,
+    LibraP2PTransferTransactionArgument, LibraRawTransaction, LibraSignedTransaction,
+    LibraTransactionPayload, TransactionType_PeerToPeer,
 };
 use lcs::to_bytes;
 use libra_crypto::{ed25519::*, test_utils::KeyPair};
@@ -18,7 +18,7 @@ use std::{convert::TryFrom, slice, time::Duration};
 use transaction_builder::encode_transfer_script;
 
 #[no_mangle]
-pub unsafe extern "C" fn libra_signed_transaction_build(
+pub unsafe extern "C" fn libra_SignedTransactionBytes_from(
     sender: *const u8,
     receiver: *const u8,
     sequence: u64,
@@ -27,8 +27,8 @@ pub unsafe extern "C" fn libra_signed_transaction_build(
     gas_unit_price: u64,
     expiration_time_secs: u64,
     private_key_bytes: *const u8,
-    buf: *mut *mut u8,
-    len: *mut usize,
+    ptr_buf: *mut *mut u8,
+    ptr_len: *mut usize,
 ) {
     let sender_buf = slice::from_raw_parts(sender, ADDRESS_LENGTH);
     let sender_address = AccountAddress::try_from(sender_buf).unwrap();
@@ -62,22 +62,22 @@ pub unsafe extern "C" fn libra_signed_transaction_build(
     let txn_buf: (*mut u8) = libc::malloc(signed_txn_bytes.len()).cast();
     txn_buf.copy_from(signed_txn_bytes.as_ptr(), signed_txn_bytes.len());
 
-    *buf = txn_buf;
-    *len = signed_txn_bytes.len();
+    *ptr_buf = txn_buf;
+    *ptr_len = signed_txn_bytes.len();
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn libra_signed_transaction_free(buf: *mut *mut u8) {
+pub unsafe extern "C" fn libra_SignedTransactionBytes_free(buf: *const u8) {
     if !buf.is_null() {
-        libc::free(*buf as *mut libc::c_void);
+        libc::free(buf as *mut libc::c_void);
     }
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn libra_signed_transaction_deserialize(
+pub unsafe extern "C" fn libra_LibraSignedTransaction_from(
     buf: *const u8,
     len: usize,
-) -> CDevSignedTransaction {
+) -> LibraSignedTransaction {
     let buffer: &[u8] = slice::from_raw_parts(buf, len);
 
     let signed_txn: SignedTransaction =
@@ -92,7 +92,7 @@ pub unsafe extern "C" fn libra_signed_transaction_deserialize(
     let public_key = signed_txn.public_key();
     let signature = signed_txn.signature();
 
-    let mut cdev_txn_payload = None;
+    let mut txn_payload = None;
 
     if let TransactionPayload::Script(script) = payload {
         let args = script.args();
@@ -109,24 +109,24 @@ pub unsafe extern "C" fn libra_signed_transaction_deserialize(
             }
             _ => {}
         });
-        cdev_txn_payload = Some(CDevTransactionPayload {
+        txn_payload = Some(LibraTransactionPayload {
             txn_type: TransactionType_PeerToPeer,
-            args: CDevP2PTransferTransactionArgument {
+            args: LibraP2PTransferTransactionArgument {
                 value: value.expect("Could not extract transaction amount from payload"),
                 address: address.expect("Could not extract receiver address from payload"),
             },
         });
     }
 
-    let raw_txn = CDevRawTransaction {
+    let raw_txn = LibraRawTransaction {
         sender,
         sequence_number,
-        payload: cdev_txn_payload.expect("Could not get transaction payload"),
+        payload: txn_payload.expect("Could not get transaction payload"),
         max_gas_amount,
         gas_unit_price,
         expiration_time_secs,
     };
-    CDevSignedTransaction {
+    LibraSignedTransaction {
         raw_txn,
         public_key: public_key.to_bytes(),
         signature: signature.to_bytes(),
@@ -162,7 +162,7 @@ fn test_lcs_signed_transaction() {
     let mut len: usize = 0;
 
     unsafe {
-        libra_signed_transaction_build(
+        libra_SignedTransactionBytes_from(
             sender_address.as_ref().as_ptr(),
             receiver_address.as_ref().as_ptr(),
             sequence,
@@ -190,7 +190,7 @@ fn test_lcs_signed_transaction() {
     assert_eq!(deserialized_signed_txn.public_key(), public_key);
     assert!(deserialized_signed_txn.check_signature().is_ok());
 
-    unsafe { libra_signed_transaction_free(&mut buf_ptr) };
+    unsafe { libra_SignedTransactionBytes_free(buf_ptr) };
 }
 
 /// Generate an Signed Transaction and deserialize
@@ -223,10 +223,7 @@ fn test_libra_signed_transaction_deserialize() {
     let proto_txn: libra_types::proto::types::SignedTransaction = signed_txn.clone().into();
 
     let result = unsafe {
-        libra_signed_transaction_deserialize(
-            proto_txn.txn_bytes.as_ptr(),
-            proto_txn.txn_bytes.len(),
-        )
+        libra_LibraSignedTransaction_from(proto_txn.txn_bytes.as_ptr(), proto_txn.txn_bytes.len())
     };
     let payload = signed_txn.payload();
     if let TransactionPayload::Script(_script) = payload {


### PR DESCRIPTION
For crafting types and returning serialized bytes of those types, we use “libra_<TypeName>Bytes_from(...)”
