### PR TITLE
[libra-dev][error-handling] Add error handling scheme

### DIFF
--- a/libra-dev/include/data.h
+++ b/libra-dev/include/data.h
@@ -12,9 +12,7 @@ extern "C" {
 
 enum LibraStatus {
     OK = 0,
-
     InvalidArgument = -1,
-
     InternalError = -255,
 };
 
@@ -79,13 +77,13 @@ enum LibraStatus libra_LibraAccountResource_from(const uint8_t *buf, size_t len,
  * @param[out] buf is the pointer that will be filled with the memory address of the transaction allocated in rust. User takes ownership of pointer returned by *buf, which needs to be freed using libra_signed_transcation_free
  * @param[out] len is the length of the signed transaction memory buffer.
 */
-void libra_SignedTransactionBytes_from(const uint8_t sender[32], const uint8_t receiver[32], uint64_t sequence, uint64_t num_coins, uint64_t max_gas_amount, uint64_t gas_unit_price, uint64_t expiration_time_secs, const uint8_t* private_key_bytes, uint8_t** ptr_buf, size_t* ptr_len);
+enum LibraStatus libra_SignedTransactionBytes_from(const uint8_t sender[32], const uint8_t receiver[32], uint64_t sequence, uint64_t num_coins, uint64_t max_gas_amount, uint64_t gas_unit_price, uint64_t expiration_time_secs, const uint8_t* private_key_bytes, uint8_t** ptr_buf, size_t* ptr_len);
 /*!
  * Function to free the allocation memory in rust for transaction
  * @param buf is the pointer to the transaction allocated in rust, and needs to be freed from client side
  */
 void libra_SignedTransactionBytes_free(const uint8_t* buf);
-struct LibraSignedTransaction libra_LibraSignedTransaction_from(const uint8_t *buf, size_t len);
+enum LibraStatus libra_LibraSignedTransaction_from(const uint8_t *buf, size_t len, struct LibraSignedTransaction *out);
 
 #ifdef __cplusplus
 };


### PR DESCRIPTION
Adding error handling scheme. All functions that return a value will have LibraStatus as the return value and the actual output will be assigned to a pointer the client passes in. 

`enum LibraStatus { 
  OK = 0,
  InvalidArgument = -1,
  InternalError = -255
}`

Client should not try to read the value unless LibraStatus::OK is returned.