### PR TITLE
[transaction][libra-dev] Adding unsupported transaction error

### DIFF
--- a/libra-dev/include/data.h
+++ b/libra-dev/include/data.h
@@ -15,6 +15,7 @@ const char* LIBRA_VERSION = "3160002c771bbf325d71759a0192ae567d586f22";
 enum LibraStatus {
     OK = 0,
     InvalidArgument = -1,
+    Unsupported = -2,
     InternalError = -255,
 };
 

--- a/libra-dev/src/data.rs
+++ b/libra-dev/src/data.rs
@@ -5,6 +5,7 @@
 pub enum LibraStatus {
     OK = 0,
     InvalidArgument = -1,
+    Unsupported = -2,
     InternalError = -255,
 }
 #[repr(C)]

--- a/libra-dev/src/transaction.rs
+++ b/libra-dev/src/transaction.rs
@@ -255,6 +255,8 @@ pub unsafe extern "C" fn libra_LibraSignedTransaction_from(
                 },
             });
         };
+    } else {
+        return LibraStatus::Unsupported;
     }
 
     let raw_txn = match txn_payload {
@@ -266,17 +268,25 @@ pub unsafe extern "C" fn libra_LibraSignedTransaction_from(
             gas_unit_price,
             expiration_time_secs,
         },
-        None => LibraRawTransaction {
-            sender,
-            sequence_number,
-            payload: LibraTransactionPayload {
-                txn_type: TransactionType::Unknown,
-                args: LibraP2PTransferTransactionArgument::default(),
-            },
-            max_gas_amount,
-            gas_unit_price,
-            expiration_time_secs,
-        },
+        None => {
+            let raw_txn_other = LibraRawTransaction {
+                sender,
+                sequence_number,
+                payload: LibraTransactionPayload {
+                    txn_type: TransactionType::Unknown,
+                    args: LibraP2PTransferTransactionArgument::default(),
+                },
+                max_gas_amount,
+                gas_unit_price,
+                expiration_time_secs,
+            };
+            *out = LibraSignedTransaction {
+                raw_txn: raw_txn_other,
+                public_key: public_key.to_bytes(),
+                signature: signature.to_bytes(),
+            };
+            return LibraStatus::Unsupported;
+        }
     };
 
     *out = LibraSignedTransaction {


### PR DESCRIPTION
Not all transaction get deserialized into a peer to peer transaction. Currently other types of txn are not supported, so we return the appropriate error so that client knows it wasn't an input issue