### PR TITLE
[libra-dev][rust] Fix testnet dependencies

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -28,8 +28,8 @@ dependencies = [
  "libra-types 0.1.0 (git+https://github.com/libra/libra.git?branch=testnet)",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "tonic 0.1.0 (git+https://github.com/hyperium/tonic.git)",
- "tonic-build 0.1.0 (git+https://github.com/hyperium/tonic.git)",
+ "tonic 0.1.0-alpha.6 (git+https://github.com/hyperium/tonic.git)",
+ "tonic-build 0.1.0-alpha.6 (git+https://github.com/hyperium/tonic.git)",
 ]
 
 [[package]]
@@ -62,7 +62,7 @@ dependencies = [
  "storage-client 0.1.0 (git+https://github.com/libra/libra.git?branch=testnet)",
  "storage-service 0.1.0 (git+https://github.com/libra/libra.git?branch=testnet)",
  "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "tonic 0.1.0 (git+https://github.com/hyperium/tonic.git)",
+ "tonic 0.1.0-alpha.6 (git+https://github.com/hyperium/tonic.git)",
  "vm-validator 0.1.0 (git+https://github.com/libra/libra.git?branch=testnet)",
 ]
 
@@ -541,7 +541,6 @@ dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "tonic 0.1.0 (git+https://github.com/hyperium/tonic.git)",
  "transaction-builder 0.1.0 (git+https://github.com/libra/libra.git?branch=testnet)",
 ]
 
@@ -662,7 +661,7 @@ dependencies = [
  "termion 1.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "tonic 0.1.0 (git+https://github.com/hyperium/tonic.git)",
+ "tonic 0.1.0-alpha.6 (git+https://github.com/hyperium/tonic.git)",
  "vm-runtime 0.1.0 (git+https://github.com/libra/libra.git?branch=testnet)",
 ]
 
@@ -886,8 +885,8 @@ dependencies = [
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "tonic 0.1.0 (git+https://github.com/hyperium/tonic.git)",
- "tonic-build 0.1.0 (git+https://github.com/hyperium/tonic.git)",
+ "tonic 0.1.0-alpha.6 (git+https://github.com/hyperium/tonic.git)",
+ "tonic-build 0.1.0-alpha.6 (git+https://github.com/hyperium/tonic.git)",
 ]
 
 [[package]]
@@ -1811,8 +1810,8 @@ dependencies = [
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-client 0.1.0 (git+https://github.com/libra/libra.git?branch=testnet)",
  "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "tonic 0.1.0 (git+https://github.com/hyperium/tonic.git)",
- "tonic-build 0.1.0 (git+https://github.com/hyperium/tonic.git)",
+ "tonic 0.1.0-alpha.6 (git+https://github.com/hyperium/tonic.git)",
+ "tonic-build 0.1.0-alpha.6 (git+https://github.com/hyperium/tonic.git)",
  "ttl_cache 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-validator 0.1.0 (git+https://github.com/libra/libra.git?branch=testnet)",
 ]
@@ -1881,7 +1880,7 @@ dependencies = [
  "storage-service 0.1.0 (git+https://github.com/libra/libra.git?branch=testnet)",
  "structopt 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "tonic 0.1.0 (git+https://github.com/hyperium/tonic.git)",
+ "tonic 0.1.0-alpha.6 (git+https://github.com/hyperium/tonic.git)",
  "vm-runtime 0.1.0 (git+https://github.com/libra/libra.git?branch=testnet)",
 ]
 
@@ -2767,15 +2766,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost-derive 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "prost-build"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2793,23 +2783,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-build"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "multimap 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost-types 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "prost-derive"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2822,33 +2795,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-derive"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "prost-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3726,7 +3678,7 @@ dependencies = [
  "storage-proto 0.1.0 (git+https://github.com/libra/libra.git?branch=testnet)",
  "structopt 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "tonic 0.1.0 (git+https://github.com/hyperium/tonic.git)",
+ "tonic 0.1.0-alpha.6 (git+https://github.com/hyperium/tonic.git)",
 ]
 
 [[package]]
@@ -4163,8 +4115,8 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.1.0"
-source = "git+https://github.com/hyperium/tonic.git#5fc6762435494d8df023bea8e35a5d20d81f2f3b"
+version = "0.1.0-alpha.6"
+source = "git+https://github.com/hyperium/tonic.git#c99d13c6e669be3a6ecf428ae32d4b937393738a"
 dependencies = [
  "async-stream 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-trait 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4177,13 +4129,13 @@ dependencies = [
  "hyper 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost-derive 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-balance 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-load 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower 0.3.0 (git+https://github.com/tower-rs/tower)",
+ "tower-balance 0.3.0 (git+https://github.com/tower-rs/tower)",
+ "tower-load 0.3.0 (git+https://github.com/tower-rs/tower)",
  "tower-make 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4192,11 +4144,11 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.1.0"
-source = "git+https://github.com/hyperium/tonic.git#5fc6762435494d8df023bea8e35a5d20d81f2f3b"
+version = "0.1.0-alpha.6"
+source = "git+https://github.com/hyperium/tonic.git#c99d13c6e669be3a6ecf428ae32d4b937393738a"
 dependencies = [
  "proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost-build 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -4204,24 +4156,24 @@ dependencies = [
 [[package]]
 name = "tower"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/tower-rs/tower#7e35b758be93a3e86256fe553f3516c78aa98d48"
 dependencies = [
  "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-buffer 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-discover 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-buffer 0.3.0 (git+https://github.com/tower-rs/tower)",
+ "tower-discover 0.3.0 (git+https://github.com/tower-rs/tower)",
  "tower-layer 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-limit 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-load-shed 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-retry 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-limit 0.3.0 (git+https://github.com/tower-rs/tower)",
+ "tower-load-shed 0.3.0 (git+https://github.com/tower-rs/tower)",
+ "tower-retry 0.3.0 (git+https://github.com/tower-rs/tower)",
  "tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-timeout 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-util 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-timeout 0.3.0 (git+https://github.com/tower-rs/tower)",
+ "tower-util 0.3.0 (git+https://github.com/tower-rs/tower)",
 ]
 
 [[package]]
 name = "tower-balance"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/tower-rs/tower#7e35b758be93a3e86256fe553f3516c78aa98d48"
 dependencies = [
  "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4230,11 +4182,11 @@ dependencies = [
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-discover 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-discover 0.3.0 (git+https://github.com/tower-rs/tower)",
  "tower-layer 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-load 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-load 0.3.0 (git+https://github.com/tower-rs/tower)",
  "tower-make 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-ready-cache 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-ready-cache 0.3.0 (git+https://github.com/tower-rs/tower)",
  "tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -4242,7 +4194,7 @@ dependencies = [
 [[package]]
 name = "tower-buffer"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/tower-rs/tower#7e35b758be93a3e86256fe553f3516c78aa98d48"
 dependencies = [
  "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4255,7 +4207,7 @@ dependencies = [
 [[package]]
 name = "tower-discover"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/tower-rs/tower#7e35b758be93a3e86256fe553f3516c78aa98d48"
 dependencies = [
  "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4270,7 +4222,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "tower-limit"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/tower-rs/tower#7e35b758be93a3e86256fe553f3516c78aa98d48"
 dependencies = [
  "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4282,20 +4234,20 @@ dependencies = [
 [[package]]
 name = "tower-load"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/tower-rs/tower#7e35b758be93a3e86256fe553f3516c78aa98d48"
 dependencies = [
  "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-discover 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-discover 0.3.0 (git+https://github.com/tower-rs/tower)",
  "tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tower-load-shed"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/tower-rs/tower#7e35b758be93a3e86256fe553f3516c78aa98d48"
 dependencies = [
  "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4315,7 +4267,7 @@ dependencies = [
 [[package]]
 name = "tower-ready-cache"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/tower-rs/tower#7e35b758be93a3e86256fe553f3516c78aa98d48"
 dependencies = [
  "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4328,7 +4280,7 @@ dependencies = [
 [[package]]
 name = "tower-retry"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/tower-rs/tower#7e35b758be93a3e86256fe553f3516c78aa98d48"
 dependencies = [
  "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4345,7 +4297,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "tower-timeout"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/tower-rs/tower#7e35b758be93a3e86256fe553f3516c78aa98d48"
 dependencies = [
  "pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4356,7 +4308,7 @@ dependencies = [
 [[package]]
 name = "tower-util"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/tower-rs/tower#7e35b758be93a3e86256fe553f3516c78aa98d48"
 dependencies = [
  "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5197,13 +5149,9 @@ dependencies = [
 "checksum proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cf147e022eacf0c8a054ab864914a7602618adba841d800a9a9868a5237a529f"
 "checksum proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d31edb17edac73aeacc947bd61462dda15220584268896a58e12f053d767f15b"
 "checksum prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96d14b1c185652833d24aaad41c5832b0be5616a590227c1fbff57c616754b23"
-"checksum prost 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "51e1bdfe79dfa6df7ed34e50060cea5108e2fc4e6d3230658770720e53cb1874"
 "checksum prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eb788126ea840817128183f8f603dce02cb7aea25c2a0b764359d8e20010702e"
-"checksum prost-build 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "33a7fe588ea94b85bc9dc3471652a9ed71727be3460c8238bca3f0e7280cf1a3"
 "checksum prost-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5e7dc378b94ac374644181a2247cebf59a6ec1c88b49ac77f3a94b86b79d0e11"
-"checksum prost-derive 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4671563225154e373c66c83c9a92468c2e333a355e2ec5abefdbcbf2539e4877"
 "checksum prost-types 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1de482a366941c8d56d19b650fac09ca08508f2a696119ee7513ad590c8bac6f"
-"checksum prost-types 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "738dd42f98597e4d9ea547b46df0fd17b9a16d2653c959feb32f918cc1d120b0"
 "checksum protobuf 2.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6686ddd96a8dbe2687b5f2a687b2cfb520854010ec480f2d74c32e7c9873d3c5"
 "checksum publicsuffix 1.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3bbaa49075179162b49acac1c6aa45fb4dafb5f13cf6794276d77bc7fd95757b"
 "checksum quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
@@ -5334,22 +5282,22 @@ dependencies = [
 "checksum tokio-timer 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "1739638e364e558128461fc1ad84d997702c8e31c2e6b18fb99842268199e827"
 "checksum tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "571da51182ec208780505a32528fc5512a8fe1443ab960b3f2f3ef093cd16930"
 "checksum toml 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "01d1404644c8b12b16bfcffa4322403a91a451584daaaa7c28d3152e6cbc98cf"
-"checksum tonic 0.1.0 (git+https://github.com/hyperium/tonic.git)" = "<none>"
-"checksum tonic-build 0.1.0 (git+https://github.com/hyperium/tonic.git)" = "<none>"
-"checksum tower 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4b299df54795e6f72bca45063b5803d1f9a1ba9b11a3c7c64d0b84519b451fdd"
-"checksum tower-balance 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a792277613b7052448851efcf98a2c433e6f1d01460832dc60bef676bc275d4c"
-"checksum tower-buffer 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c4887dc2a65d464c8b9b66e0e4d51c2fd6cf5b3373afc72805b0a60bce00446a"
-"checksum tower-discover 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0f6b5000c3c54d269cc695dff28136bb33d08cbf1df2c48129e143ab65bf3c2a"
+"checksum tonic 0.1.0-alpha.6 (git+https://github.com/hyperium/tonic.git)" = "<none>"
+"checksum tonic-build 0.1.0-alpha.6 (git+https://github.com/hyperium/tonic.git)" = "<none>"
+"checksum tower 0.3.0 (git+https://github.com/tower-rs/tower)" = "<none>"
+"checksum tower-balance 0.3.0 (git+https://github.com/tower-rs/tower)" = "<none>"
+"checksum tower-buffer 0.3.0 (git+https://github.com/tower-rs/tower)" = "<none>"
+"checksum tower-discover 0.3.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tower-layer 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a35d656f2638b288b33495d1053ea74c40dc05ec0b92084dd71ca5566c4ed1dc"
-"checksum tower-limit 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0a4030a1dc1ab99ec6fc9475fc18c62f6cc4da035d370fcbd22fe342f9dd16cd"
-"checksum tower-load 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8cc79fc3afd07492b7966d7efa7c6c50f8ed58d768a6075dd7ae6591c5d2017b"
-"checksum tower-load-shed 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9f021e23900173dc315feb4b6922510dae3e79c689b74c089112066c11f0ae4e"
+"checksum tower-limit 0.3.0 (git+https://github.com/tower-rs/tower)" = "<none>"
+"checksum tower-load 0.3.0 (git+https://github.com/tower-rs/tower)" = "<none>"
+"checksum tower-load-shed 0.3.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tower-make 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce50370d644a0364bf4877ffd4f76404156a248d104e2cc234cd391ea5cdc965"
-"checksum tower-ready-cache 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b2183d0a00b68a41c0af9e281cf51f40c7de2e1d4af4a43f92a5c35bbe7728d7"
-"checksum tower-retry 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e6727956aaa2f8957d4d9232b308fe8e4e65d99db30f42b225646e86c9b6a952"
+"checksum tower-ready-cache 0.3.0 (git+https://github.com/tower-rs/tower)" = "<none>"
+"checksum tower-retry 0.3.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
-"checksum tower-timeout 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "127b8924b357be938823eaaec0608c482d40add25609481027b96198b2e4b31e"
-"checksum tower-util 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5702d7890e35b2aae6ee420e8a762547505dbed30c075fbc84ec069a0aa18314"
+"checksum tower-timeout 0.3.0 (git+https://github.com/tower-rs/tower)" = "<none>"
+"checksum tower-util 0.3.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tracing 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "6de6a8590a29d3f401eab60470c699efa0adf7b4f0352055bf24df2b69849b40"
 "checksum tracing-attributes 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04cfd395def5a60236e187e1ff905cb55668a59f29928dec05e6e1b1fd2ac1f3"
 "checksum tracing-core 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "13a46f11e372b8bd4b4398ea54353412fdd7fd42a8370c7e543e218cf7661978"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -14,7 +14,6 @@ anyhow = "1.0"
 chrono = "0.4.7"
 futures = "0.1.28"
 grpcio = { version = "=0.5.0-alpha.4", default-features = false, features = ["prost-codec"] }
-tonic = { git = "https://github.com/hyperium/tonic.git" }
 hex = "0.3.2"
 itertools = "0.8.0"
 proptest = { version = "0.9.2", optional = true }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -5,6 +5,7 @@
 
 use chrono::prelude::{SecondsFormat, Utc};
 use client::{client_proxy::ClientProxy, commands::*};
+use fixme_libra_types::waypoint::Waypoint;
 use libra_logger::set_default_global_logger;
 use rustyline::{config::CompletionType, error::ReadlineError, Config, Editor};
 use std::num::NonZeroU16;
@@ -51,6 +52,9 @@ struct Args {
     /// If set, client will sync with validator during wallet recovery.
     #[structopt(short = "r", long = "sync")]
     pub sync: bool,
+    /// If set, a client uses the waypoint parameter for its initial LedgerInfo verification.
+    #[structopt(name = "waypoint", short, long)]
+    pub waypoint: Option<Waypoint>,
     /// Verbose output.
     #[structopt(short = "v", long = "verbose")]
     pub verbose: bool,
@@ -68,11 +72,11 @@ fn main() -> std::io::Result<()> {
     let mut client_proxy = ClientProxy::new(
         &args.host,
         args.port.get(),
-        &args.validator_set_file,
         &faucet_account_file,
         args.sync,
         args.faucet_server,
         args.mnemonic_file,
+        args.waypoint,
     )
     .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, &format!("{}", e)[..]))?;
 

--- a/rust/src/query_commands.rs
+++ b/rust/src/query_commands.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{client_proxy::ClientProxy, commands::*};
-use fixme_libra_types::account_config::get_account_resource_or_default;
+//use fixme_libra_types::account_config::get_account_resource_or_default;
 use fixme_transaction_builder::get_transaction_name;
 
 /// Major command for query operations.
@@ -93,20 +93,17 @@ impl Command for QueryCommandGetLatestAccountState {
     fn execute(&self, client: &mut ClientProxy, params: &[&str]) {
         println!(">> Getting latest account state");
         match client.get_latest_account_state(&params) {
-            Ok((acc, version)) => match get_account_resource_or_default(&acc) {
-                Ok(_) => println!(
-                    "Latest account state is: \n \
-                     Account: {:#?}\n \
-                     State: {:#?}\n \
-                     Blockchain Version: {}\n",
-                    client
-                        .get_account_address_from_parameter(params[1])
-                        .expect("Unable to parse account parameter"),
-                    acc,
-                    version,
-                ),
-                Err(e) => report_error("Error converting account blob to account resource", e),
-            },
+            Ok((acc, version)) => println!(
+                "Latest account state is: \n \
+                 Account: {:#?}\n \
+                 State: {:#?}\n \
+                 Blockchain Version: {}\n",
+                client
+                    .get_account_address_from_parameter(params[1])
+                    .expect("Unable to parse account parameter"),
+                acc,
+                version,
+            ),
             Err(e) => report_error("Error getting latest account state", e),
         }
     }

--- a/rust/tests/libratest/smoke_test.rs
+++ b/rust/tests/libratest/smoke_test.rs
@@ -5,6 +5,8 @@ use client::{
     association_address, client_proxy::ClientProxy, AccountAddress, CryptoHash,
     TransactionArgument, TransactionPayload,
 };
+use fixme_lcs::from_bytes;
+use fixme_libra_types::waypoint::Waypoint;
 use libra_config::config::{NodeConfig, RoleType};
 use libra_crypto::{ed25519::*, test_utils::KeyPair, SigningKey};
 use libra_logger::prelude::*;
@@ -13,43 +15,48 @@ use libra_swarm::{swarm::LibraSwarm, utils};
 use libra_tools::tempdir::TempPath;
 use num_traits::cast::FromPrimitive;
 use rust_decimal::Decimal;
-use std::fs;
+use std::fs::{self, File};
+use std::io::Read;
 use std::str::FromStr;
 use std::{thread, time};
 
 struct TestEnvironment {
     validator_swarm: LibraSwarm,
     full_node_swarm: Option<LibraSwarm>,
-    faucet_key: (
-        KeyPair<Ed25519PrivateKey, Ed25519PublicKey>,
-        String,
-        Option<TempPath>,
-    ),
+    faucet_key: (KeyPair<Ed25519PrivateKey, Ed25519PublicKey>, String),
     mnemonic_file: TempPath,
 }
 
 impl TestEnvironment {
     fn new(num_validators: usize) -> Self {
         ::libra_logger::init_for_e2e_testing();
-        let faucet_key = generate_keypair::load_faucet_key_or_create_default(None);
-        let validator_swarm = LibraSwarm::configure_swarm(
-            num_validators,
-            RoleType::Validator,
-            faucet_key.0.clone(),
-            None,
-            None,
-            None,
-        )
-        .unwrap();
+        let validator_swarm =
+            LibraSwarm::configure_swarm(num_validators, RoleType::Validator, None, None, None)
+                .unwrap();
 
         let mnemonic_file = libra_tools::tempdir::TempPath::new();
         mnemonic_file
             .create_as_file()
             .expect("could not create temporary mnemonic_file_path");
+
+        let mut key_file = File::open(&validator_swarm.config.faucet_key_path)
+            .expect("Unable to create faucet key file");
+        let mut serialized_key = Vec::new();
+        key_file
+            .read_to_end(&mut serialized_key)
+            .expect("Unable to read serialized faucet key");
+        let keypair = from_bytes(&serialized_key).expect("Unable to deserialize faucet key");
+        let keypair_path = validator_swarm
+            .config
+            .faucet_key_path
+            .to_str()
+            .expect("Unable to read faucet path")
+            .to_string();
+
         Self {
             validator_swarm,
             full_node_swarm: None,
-            faucet_key,
+            faucet_key: (keypair, keypair_path),
             mnemonic_file,
         }
     }
@@ -59,7 +66,6 @@ impl TestEnvironment {
             LibraSwarm::configure_swarm(
                 num_full_nodes,
                 RoleType::FullNode,
-                self.faucet_key.0.clone(),
                 None,
                 None,
                 Some(String::from(
@@ -94,14 +100,7 @@ impl TestEnvironment {
         panic!("Max out {} attempts to launch test swarm", num_attempts);
     }
 
-    fn get_ac_client(&self, port: u16) -> ClientProxy {
-        let config = NodeConfig::load(&self.validator_swarm.config.config_files[0]).unwrap();
-        let validator_set_file = self
-            .validator_swarm
-            .dir
-            .as_ref()
-            .join("0")
-            .join(&config.consensus.consensus_peers_file);
+    fn get_ac_client(&self, port: u16, waypoint: Option<Waypoint>) -> ClientProxy {
         let mnemonic_file_path = self
             .mnemonic_file
             .path()
@@ -115,25 +114,33 @@ impl TestEnvironment {
         ClientProxy::new(
             "localhost",
             port,
-            validator_set_file.to_str().unwrap(),
             &self.faucet_key.1,
             false,
             /* faucet server */ None,
             Some(mnemonic_file_path),
+            waypoint,
         )
         .unwrap()
     }
 
-    fn get_validator_ac_client(&self, node_index: usize) -> ClientProxy {
+    fn get_validator_ac_client(
+        &self,
+        node_index: usize,
+        waypoint: Option<Waypoint>,
+    ) -> ClientProxy {
         let port = self.validator_swarm.get_ac_port(node_index);
-        self.get_ac_client(port)
+        self.get_ac_client(port, waypoint)
     }
 
-    fn get_full_node_ac_client(&self, node_index: usize) -> ClientProxy {
+    fn get_full_node_ac_client(
+        &self,
+        node_index: usize,
+        waypoint: Option<Waypoint>,
+    ) -> ClientProxy {
         match &self.full_node_swarm {
             Some(swarm) => {
                 let port = swarm.get_ac_port(node_index);
-                self.get_ac_client(port)
+                self.get_ac_client(port, waypoint)
             }
             None => {
                 panic!("Full Node swarm is not initialized");
@@ -152,7 +159,7 @@ fn setup_swarm_and_client_proxy(
 ) -> (TestEnvironment, ClientProxy) {
     let mut env = TestEnvironment::new(num_nodes);
     env.launch_swarm(RoleType::Validator);
-    let ac_client = env.get_validator_ac_client(client_port_index);
+    let ac_client = env.get_validator_ac_client(client_port_index, None);
     (env, ac_client)
 }
 
@@ -203,7 +210,8 @@ fn test_execute_custom_module_and_script() {
     let recipient_address = client_proxy.create_next_account(false).unwrap().address;
     client_proxy.mint_coins(&["mintb", "1", "1"], true).unwrap();
 
-    let module_path = utils::workspace_root().join("tests/libratest/dev_modules/module.mvir");
+    let module_path =
+        utils::workspace_root().join("testsuite/tests/libratest/dev_modules/module.mvir");
     let unwrapped_module_path = module_path.to_str().unwrap();
     let module_params = &["compile", "0", unwrapped_module_path, "module"];
     let module_compiled_path = client_proxy.compile_program(module_params).unwrap();
@@ -212,7 +220,8 @@ fn test_execute_custom_module_and_script() {
         .publish_module(&["publish", "0", &module_compiled_path[..]])
         .unwrap();
 
-    let script_path = utils::workspace_root().join("tests/libratest/dev_modules/script.mvir");
+    let script_path =
+        utils::workspace_root().join("testsuite/tests/libratest/dev_modules/script.mvir");
     let unwrapped_script_path = script_path.to_str().unwrap();
     let script_params = &["execute", "0", unwrapped_script_path, "script"];
     let script_compiled_path = client_proxy.compile_program(script_params).unwrap();
@@ -388,7 +397,7 @@ fn test_startup_sync_state() {
         .is_ok());
     // create the client for the restarted node
     let accounts = client_proxy_1.copy_all_accounts();
-    let mut client_proxy_0 = env.get_validator_ac_client(0);
+    let mut client_proxy_0 = env.get_validator_ac_client(0, None);
     let sender_address = accounts[0].address;
     client_proxy_0.set_accounts(accounts);
     client_proxy_0.wait_for_transaction(sender_address, 1);
@@ -464,7 +473,7 @@ fn test_basic_state_synchronization() {
     assert!(env.validator_swarm.wait_for_all_nodes_to_catchup());
 
     // Connect to the newly recovered node and verify its state
-    let mut client_proxy2 = env.get_validator_ac_client(node_to_restart);
+    let mut client_proxy2 = env.get_validator_ac_client(node_to_restart, None);
     client_proxy2.set_accounts(client_proxy.copy_all_accounts());
     assert_eq!(
         Decimal::from_f64(85.0),
@@ -579,12 +588,12 @@ fn test_full_node_basic_flow() {
     env.launch_swarm(RoleType::FullNode);
 
     // execute smoke script
-    test_smoke_script(env.get_validator_ac_client(0));
+    test_smoke_script(env.get_validator_ac_client(0, None));
 
     // read state from full node client
-    let mut validator_ac_client = env.get_validator_ac_client(1);
-    let mut full_node_client = env.get_full_node_ac_client(1);
-    let mut full_node_client_2 = env.get_full_node_ac_client(0);
+    let mut validator_ac_client = env.get_validator_ac_client(1, None);
+    let mut full_node_client = env.get_full_node_ac_client(1, None);
+    let mut full_node_client_2 = env.get_full_node_ac_client(0, None);
     for idx in 0..3 {
         validator_ac_client.create_next_account(false).unwrap();
         full_node_client.create_next_account(false).unwrap();
@@ -699,7 +708,7 @@ fn test_full_node_basic_flow() {
 fn test_e2e_reconfiguration() {
     let (mut env, mut client_proxy_1) = setup_swarm_and_client_proxy(3, 1);
     // the client connected to the removed validator
-    let mut client_proxy_0 = env.get_validator_ac_client(0);
+    let mut client_proxy_0 = env.get_validator_ac_client(0, None);
     client_proxy_1.create_next_account(false).unwrap();
     client_proxy_0.set_accounts(client_proxy_1.copy_all_accounts());
     client_proxy_1


### PR DESCRIPTION
Testnet update broke a lot of client code, so updating the test for fix. It was mostly due to update to tonic, and combining sync and async versions of the functions.

Since testnet tonic version is different from what we're generating in Cargo.lock, you need to run `cargo update -p tonic --precise c99d13c6e669be3a6ecf428ae32d4b937393738a` to specify a tonic version