### PR TITLE
[pylibra] fix JSONToLBRExchangeRateUpdateEvent missing Event fields

### DIFF
--- a/python/src/pylibra/_jsonrpc_transport.py
+++ b/python/src/pylibra/_jsonrpc_transport.py
@@ -293,6 +293,26 @@ class JSONToLBRExchangeRateUpdateEvent(ToLBRExchangeRateUpdateEvent):
     def new_to_lbr_exchange_rate(self) -> float:
         return self._ev_dict["data"]["new_to_lbr_exchange_rate"]
 
+    @property
+    def module(self) -> str:
+        return "LibraExchangeRate"
+
+    @property
+    def name(self) -> str:
+        return "ToLBRExchangeRateUpdate"
+
+    @property
+    def key(self) -> bytes:
+        return bytes.fromhex(self._ev_dict["key"])
+
+    @property
+    def sequence_number(self) -> int:
+        return self._ev_dict["sequence_number"]
+
+    @property
+    def transaction_version(self) -> int:
+        return self._ev_dict["transaction_version"]
+
 
 class JSONUnknownEvent(Event):
     _ev_dict: dict

--- a/python/tests/test_events.py
+++ b/python/tests/test_events.py
@@ -117,8 +117,19 @@ def assert_all_types_events(events: EventsType) -> None:
     assert e.currency_code == "Coin1"
     assert e.new_to_lbr_exchange_rate == 0.32
 
+    assert e.module == "LibraExchangeRate"
+    assert e.name == "ToLBRExchangeRateUpdate"
+    assert e.key.hex() == "2ef0"
+    assert e.sequence_number == 4
+    assert e.transaction_version == 8
+
 
 def create_event_dict(type: str, attrs: Dict[str, Any] = {}) -> Dict[str, Any]:
     data = {"type": type}
     data.update(attrs)
-    return {"data": data}
+    return {
+        "data": data,
+        "key": "2ef0",
+        "sequence_number": 4,
+        "transaction_version": 8,
+    }


### PR DESCRIPTION
Missed Event required fields in previous commit, added them in this change.