### PR TITLE
upgrade requests version avoiding security bug; downgrade cryptography to match fbcode

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-requests==2.19
-cryptography==3.1
+requests==2.20.0
+cryptography==2.8
 numpy==1.18
 protobuf==3.12.4
 pytest

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     packages=["libra"],
     include_package_data=True,  # see MANIFEST.in
     zip_safe=True,
-    install_requires=["requests>=2.19", "cryptography>=3.1", "numpy>=1.18", "protobuf>=3.12.4"],
+    install_requires=["requests>=2.20.0", "cryptography>=2.8", "numpy>=1.18", "protobuf>=3.12.4"],
     setup_requires=[
         # Setuptools 18.0 properly handles Cython extensions.
         "setuptools>=18.0",


### PR DESCRIPTION
CVE-2018-18074
moderate severity
Vulnerable versions: <= 2.19.1
Patched version: 2.20.0
The Requests package through 2.19.1 before 2018-09-14 for Python sends an HTTP Authorization header to an http URI upon receiving a same-hostname https-to-http redirect, which makes it easier for remote attackers to discover credentials by sniffing the network.

fbcode uses cryptography==2.8, downgrade lowest version to match