### PR TITLE
new release: do not include pyi file which got errors in fbcode, split currency_code utils into 2 funcs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 # Copyright (c) The Libra Core Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-recursive-include src *.py *.pyi
+recursive-include src *.py

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name="libra-client-sdk",
-    version="0.6.2020101401", # bump up version for release, format 0.X.YYYYMMDDNN
+    version="0.6.2020101402", # bump up version for release, format 0.X.YYYYMMDDNN
     description="The Python Client SDK for Libra",
     long_description=long_description,
     long_description_content_type='text/markdown',
@@ -19,7 +19,7 @@ setup(
     # author="Libra Open Source",
     python_requires=">=3.7", # requires dataclasses
     packages=["libra"],
-    package_data={"": ["src/libra/jsonrpc/*.pyi"]},
+    # package_data={"": ["src/libra/jsonrpc/*.pyi"]},
     package_dir={"": "src"},
     include_package_data=True,  # see MANIFEST.in
     zip_safe=True,

--- a/src/libra/utils.py
+++ b/src/libra/utils.py
@@ -89,8 +89,8 @@ def public_key_bytes(public_key: Ed25519PublicKey) -> bytes:
     return public_key.public_bytes(encoding=serialization.Encoding.Raw, format=serialization.PublicFormat.Raw)
 
 
-def currency_code(code: typing.Union[str, libra_types.TypeTag]) -> typing.Union[str, libra_types.TypeTag]:
-    """converts currency code between string and libra_types.TypeTag"""
+def currency_code(code: str) -> libra_types.TypeTag:
+    """converts currency code string to libra_types.TypeTag"""
 
     if isinstance(code, str):
         return libra_types.TypeTag__Struct(
@@ -101,6 +101,13 @@ def currency_code(code: typing.Union[str, libra_types.TypeTag]) -> typing.Union[
                 type_params=[],
             )
         )
+
+    raise TypeError(f"unknown currency code type: {code}")
+
+
+def type_tag_to_str(code: libra_types.TypeTag) -> str:
+    """converts currency code TypeTag into string"""
+
     if isinstance(code, libra_types.TypeTag__Struct):
         return code.value.name.value
 

--- a/tests/test_testnet.py
+++ b/tests/test_testnet.py
@@ -174,7 +174,7 @@ def test_get_account_transactions_with_events():
     script_call = utils.decode_transaction_script(txn)
     assert type(script_call).__name__ == "ScriptCall__PeerToPeerWithMetadata"
     assert script_call.amount > 0
-    currency_code = utils.currency_code(script_call.currency)
+    currency_code = utils.type_tag_to_str(script_call.currency)
     assert currency_code in ["LBR", "Coin1"]
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -42,11 +42,14 @@ def test_currency_code():
     ccode = utils.currency_code("Coin1")
     assert isinstance(ccode, libra_types.TypeTag)
 
-    code = utils.currency_code(ccode)
+    code = utils.type_tag_to_str(ccode)
     assert code == "Coin1"
 
     with pytest.raises(TypeError):
         utils.currency_code(False)
+
+    with pytest.raises(TypeError):
+        utils.type_tag_to_str(False)
 
 
 def test_decode_transaction_script():


### PR DESCRIPTION
1. fbcode pyre checks pyi file has error, probably caused by old protobuf version inside fbcode
2. split currency_code util, so that we don't need typing.cast for returned value