### PR TITLE
change error code to use underscore instead of hyphen

### DIFF
--- a/examples/vasp/test_offchain_error_cases.py
+++ b/examples/vasp/test_offchain_error_cases.py
@@ -31,7 +31,7 @@ def test_send_command_failed_by_invalid_jws_signature_and_retry_by_bg_job(monkey
         with pytest.raises(CommandResponseError) as err:
             sender_app.run_once_background_job()
 
-        assert_response_command_error(err.value.resp, "invalid-jws-signature")
+        assert_response_command_error(err.value.resp, "invalid_jws_signature")
 
         assert len(sender_app.saved_commands) == 1
         assert len(receiver_app.saved_commands) == 0
@@ -112,14 +112,14 @@ def test_invalid_command_request_json(sender_app, receiver_app):
     resp = send_request("invalid_request_json", sender_app, receiver_app, "failure")
 
     assert resp.cid is None
-    assert_response_command_error(resp, "invalid-object")
+    assert_response_command_error(resp, "invalid_object")
 
 
 def test_invalid_json(sender_app, receiver_app):
     resp = send_request_json("invalid_json", sender_app, receiver_app, "failure")
 
     assert resp.cid is None
-    assert_response_command_error(resp, "invalid-json")
+    assert_response_command_error(resp, "invalid_json")
 
 
 def test_missing_required_fields(sender_app, receiver_app):
@@ -133,7 +133,7 @@ def test_missing_required_fields(sender_app, receiver_app):
         new_req = copy.deepcopy(request)
         set_field(new_req, field, None)
         resp = send_request(new_req, sender_app, receiver_app, "failure")
-        assert_response_command_error(resp, "missing-field", field)
+        assert_response_command_error(resp, "missing_field", field)
 
 
 def test_unknown_fields(sender_app, receiver_app):
@@ -144,7 +144,7 @@ def test_unknown_fields(sender_app, receiver_app):
         unknown_field = field + "-unknown"
         set_field(new_req, unknown_field, "any")
         resp = send_request(new_req, sender_app, receiver_app, "failure")
-        assert_response_command_error(resp, "unknown-field", unknown_field)
+        assert_response_command_error(resp, "unknown_field", unknown_field)
 
 
 def test_invalid_field_value(sender_app, receiver_app):
@@ -166,7 +166,7 @@ def test_invalid_field_value(sender_app, receiver_app):
         new_req = copy.deepcopy(request)
         set_field(new_req, field, "invalid-value")
         resp = send_request(new_req, sender_app, receiver_app, "failure")
-        assert_response_command_error(resp, "invalid-field-value", field)
+        assert_response_command_error(resp, "invalid_field_value", field)
 
 
 def test_invalid_field_value_type(sender_app, receiver_app):
@@ -180,7 +180,7 @@ def test_invalid_field_value_type(sender_app, receiver_app):
         new_req = copy.deepcopy(request)
         set_field(new_req, field, "invalid-value-type")
         resp = send_request(new_req, sender_app, receiver_app, "failure")
-        assert_response_command_error(resp, "invalid-field-value", field)
+        assert_response_command_error(resp, "invalid_field_value", field)
 
 
 def test_invalid_actor_metadata_item_type(sender_app, receiver_app):
@@ -189,7 +189,7 @@ def test_invalid_actor_metadata_item_type(sender_app, receiver_app):
     field = "command.payment.sender.metadata"
     set_field(request, field, ["1", 2])
     resp = send_request(request, sender_app, receiver_app, "failure")
-    assert_response_command_error(resp, "invalid-field-value", field)
+    assert_response_command_error(resp, "invalid_field_value", field)
 
 
 def test_written_once_payment_actor_kyc_data(sender_app, receiver_app):
@@ -295,35 +295,35 @@ def test_travel_rule_limit_validation(sender_app, receiver_app):
     request = minimum_required_fields_request_sample(sender_app, receiver_app, 10)
 
     resp = send_request(request, sender_app, receiver_app, "failure")
-    assert_response_command_error(resp, "no-kyc-needed", "command.payment.action.amount")
+    assert_response_command_error(resp, "no_kyc_needed", "command.payment.action.amount")
 
 
 def test_invalid_currency_code(sender_app, receiver_app):
     request = minimum_required_fields_request_sample(sender_app, receiver_app, currency="XXX")
 
     resp = send_request(request, sender_app, receiver_app, "failure")
-    assert_response_command_error(resp, "invalid-field-value", "command.payment.action.currency")
+    assert_response_command_error(resp, "invalid_field_value", "command.payment.action.currency")
 
 
 def test_cid_uuid(sender_app, receiver_app):
     request = minimum_required_fields_request_sample(sender_app, receiver_app)
     request["cid"] = "invalid uuid"
     resp = send_request(request, sender_app, receiver_app, "failure")
-    assert_response_command_error(resp, "invalid-field-value", "cid")
+    assert_response_command_error(resp, "invalid_field_value", "cid")
 
 
 def test_reference_id_uuid(sender_app, receiver_app):
     request = minimum_required_fields_request_sample(sender_app, receiver_app)
     request["command"]["payment"]["reference_id"] = "invalid uuid"
     resp = send_request(request, sender_app, receiver_app, "failure")
-    assert_response_command_error(resp, "invalid-field-value", "command.payment.reference_id")
+    assert_response_command_error(resp, "invalid_field_value", "command.payment.reference_id")
 
 
 def test_unknown_actor_address_could_not_find_request_receiver_account_id(sender_app, receiver_app):
     request = minimum_required_fields_request_sample(sender_app, receiver_app)
     request["command"]["payment"]["receiver"]["address"] = sender_app.offchain_client.my_compliance_key_account_id
     resp = send_request(request, sender_app, receiver_app, "failure")
-    assert_response_command_error(resp, "unknown-actor-address")
+    assert_response_command_error(resp, "unknown_actor_address")
 
 
 def test_x_request_sender_address_must_one_of_actor_addresses(sender_app, receiver_app):
@@ -335,7 +335,7 @@ def test_x_request_sender_address_must_one_of_actor_addresses(sender_app, receiv
         "failure",
         sender_address=sender_app.offchain_client.my_compliance_key_account_id,
     )
-    assert_response_command_error(resp, "invalid-x-request-sender-address")
+    assert_response_command_error(resp, "invalid_x_request_sender_address")
 
 
 def test_http_header_x_request_sender_address_missing(sender_app, receiver_app):
@@ -343,7 +343,7 @@ def test_http_header_x_request_sender_address_missing(sender_app, receiver_app):
     resp = send_request_json_with_headers(
         json.dumps(request), sender_app, receiver_app, "failure", {http_header.X_REQUEST_ID: str(uuid.uuid4())}
     )
-    assert_response_protocol_error(resp, "missing-http-header")
+    assert_response_protocol_error(resp, "missing_http_header")
 
 
 def test_could_not_find_onchain_account_by_x_request_sender_address(sender_app, receiver_app):
@@ -352,7 +352,7 @@ def test_could_not_find_onchain_account_by_x_request_sender_address(sender_app, 
     request = minimum_required_fields_request_sample(sender_app, receiver_app)
     request["command"]["payment"]["sender"]["address"] = account_id
     resp = send_request(request, sender_app, receiver_app, "failure", sender_address=account_id)
-    assert_response_protocol_error(resp, "invalid-x-request-sender-address")
+    assert_response_protocol_error(resp, "invalid_x_request_sender_address")
 
 
 def test_could_not_find_compliance_key_of_x_request_sender_address(sender_app, receiver_app):
@@ -361,7 +361,7 @@ def test_could_not_find_compliance_key_of_x_request_sender_address(sender_app, r
     request = minimum_required_fields_request_sample(sender_app, receiver_app)
     request["command"]["payment"]["sender"]["address"] = account_id
     resp = send_request(request, sender_app, receiver_app, "failure", sender_address=account_id)
-    assert_response_protocol_error(resp, "invalid-x-request-sender-address")
+    assert_response_protocol_error(resp, "invalid_x_request_sender_address")
 
 
 def test_invalid_recipient_signature(sender_app, receiver_app):
@@ -378,7 +378,7 @@ def test_invalid_recipient_signature(sender_app, receiver_app):
     with pytest.raises(CommandResponseError) as err:
         assert receiver_app._send_request(invalid_sig_cmd)
 
-    assert_response_command_error(err.value.resp, "invalid-recipient-signature", "command.payment.recipient_signature")
+    assert_response_command_error(err.value.resp, "invalid_recipient_signature", "command.payment.recipient_signature")
 
 
 def test_receiver_actor_is_ready_for_settlement_but_recipient_signature_is_none(sender_app, receiver_app):
@@ -395,7 +395,7 @@ def test_receiver_actor_is_ready_for_settlement_but_recipient_signature_is_none(
     with pytest.raises(CommandResponseError) as err:
         assert receiver_app._send_request(missing_sig_cmd)
 
-    assert_response_command_error(err.value.resp, "missing-field", "command.payment.recipient_signature")
+    assert_response_command_error(err.value.resp, "missing_field", "command.payment.recipient_signature")
 
 
 def test_invalid_recipient_signature_hex(sender_app, receiver_app):
@@ -412,7 +412,7 @@ def test_invalid_recipient_signature_hex(sender_app, receiver_app):
     with pytest.raises(CommandResponseError) as err:
         assert receiver_app._send_request(invalid_sig_cmd)
 
-    assert_response_command_error(err.value.resp, "invalid-recipient-signature", "command.payment.recipient_signature")
+    assert_response_command_error(err.value.resp, "invalid_recipient_signature", "command.payment.recipient_signature")
 
 
 def replace_actor(cmd, name, actor, **changes):
@@ -471,7 +471,7 @@ def assert_invalid_overwrite_error(sender_app, receiver_app, field, update_cmd, 
     with pytest.raises(CommandResponseError) as err:
         sender_app.run_once_background_job()
 
-    assert_response_command_error(err.value.resp, "invalid-overwrite", field)
+    assert_response_command_error(err.value.resp, "invalid_overwrite", field)
 
 
 def assert_response_command_error(resp, code, field=None):

--- a/src/diem/offchain/types/command_types.py
+++ b/src/diem/offchain/types/command_types.py
@@ -24,56 +24,56 @@ class CommandResponseStatus:
 class ErrorCode:
     # PaymentActionObject#amount is under travel rule threshold, no kyc needed for
     # the transaction
-    no_kyc_needed = "no-kyc-needed"
+    no_kyc_needed = "no_kyc_needed"
 
     # can't transit from prior payment to new payment
-    invalid_transition = "invalid-transition"
+    invalid_transition = "invalid_transition"
 
     # the producer of the command is not right actor, for example:
     # if next actor to change the payment is sender, but receiver send a new command
     # with payment object change.
     # question: should we allow it for the case like appending metadata?
-    invalid_command_producer = "invalid-command-producer"
+    invalid_command_producer = "invalid_command_producer"
 
     # object is not valid, type does not match
-    invalid_object = "invalid-object"
+    invalid_object = "invalid_object"
     # missing required field, field value is required for a specific state
     # for example:
     #     1. when sender init the request, kyc_data is missing, or
     #     2. set sender#status#status to none at any time.
-    missing_field = "missing-field"
+    missing_field = "missing_field"
     # field value type is wrong
     # field value is not one of expected values
-    invalid_field_value = "invalid-field-value"
-    unknown_field = "unknown-field"
+    invalid_field_value = "invalid_field_value"
+    unknown_field = "unknown_field"
 
     # request content is not valid json
-    invalid_json = "invalid-json"
+    invalid_json = "invalid_json"
 
     # decode JWS content failed
-    invalid_jws = "invalid-jws"
+    invalid_jws = "invalid_jws"
     # validate JWS signature failed
-    invalid_jws_signature = "invalid-jws-signature"
+    invalid_jws_signature = "invalid_jws_signature"
 
     # request comment_type value is unknown
-    unknown_command_type = "unknown-command-type"
+    unknown_command_type = "unknown_command_type"
 
     # 1. could not find actor's onchain account by address
     # 2. none of actor addresses is server's (parent / child) vasp or dd address
-    unknown_actor_address = "unknown-actor-address"
+    unknown_actor_address = "unknown_actor_address"
 
     # overwrite write once / immutable field value
-    invalid_overwrite = "invalid-overwrite"
+    invalid_overwrite = "invalid_overwrite"
 
     # could not find command by reference_id for a non-initial command
-    invalid_initial_or_prior_not_found = "invalid-initial-or-prior-not-found"
-    invalid_x_request_sender_address = "invalid-x-request-sender-address"
+    invalid_initial_or_prior_not_found = "invalid_initial_or_prior_not_found"
+    invalid_x_request_sender_address = "invalid_x_request_sender_address"
 
     # the command is conflict with another command updating in progress by reference id
     conflict = "conflict"
 
-    missing_http_header = "missing-http-header"
-    invalid_recipient_signature = "invalid-recipient-signature"
+    missing_http_header = "missing_http_header"
+    invalid_recipient_signature = "invalid_recipient_signature"
 
 
 class OffChainErrorType:

--- a/tests/test_offchain_types.py
+++ b/tests/test_offchain_types.py
@@ -316,13 +316,13 @@ def test_invalid_object():
     with pytest.raises(offchain.FieldError, match="expect json object, but got int: ") as e:
         offchain.from_json(request_json)
 
-    assert e.value.code == "invalid-object"
+    assert e.value.code == "invalid_object"
 
     request_json = "[22]"
     with pytest.raises(offchain.FieldError, match="expect json object, but got list: ") as e:
         offchain.from_json(request_json)
 
-    assert e.value.code == "invalid-object"
+    assert e.value.code == "invalid_object"
 
 
 def test_field_value_because_of_invalid_object_type_for_union_type():
@@ -335,7 +335,7 @@ def test_field_value_because_of_invalid_object_type_for_union_type():
     with pytest.raises(offchain.FieldError, match="expect json object, but got str: ") as e:
         offchain.from_json(request_json)
 
-    assert e.value.code == "invalid-field-value"
+    assert e.value.code == "invalid_field_value"
 
 
 def test_invalid_object_type():
@@ -350,7 +350,7 @@ def test_invalid_object_type():
     with pytest.raises(offchain.FieldError, match="could not find object type: InvalidCommand") as e:
         offchain.from_json(request_json)
 
-    assert e.value.code == "invalid-field-value"
+    assert e.value.code == "invalid_field_value"
 
 
 def test_object_type_is_not_provided_when_it_is_required():
@@ -359,7 +359,7 @@ def test_object_type_is_not_provided_when_it_is_required():
         "command_type": "PaymentCommand",
         "command": {"_ObjectType": "PaymentCommand"},
     }
-    assert_field_error(request_json, "missing-field", "_ObjectType", "missing field: _ObjectType")
+    assert_field_error(request_json, "missing_field", "_ObjectType", "missing field: _ObjectType")
 
     request_json = {
         "cid": "3185027f-0574-6f55-2668-3a38fdb5de98",
@@ -367,14 +367,14 @@ def test_object_type_is_not_provided_when_it_is_required():
         "command": {},
         "_ObjectType": "CommandRequestObject",
     }
-    assert_field_error(request_json, "missing-field", "command._ObjectType", "missing field: command._ObjectType")
+    assert_field_error(request_json, "missing_field", "command._ObjectType", "missing field: command._ObjectType")
 
 
 def test_invalid_enum_field_value():
     request_json = set_field(sample_request_json(), {"command.payment.sender.status.status": "invalid"})
     assert_field_error(
         request_json,
-        "invalid-field-value",
+        "invalid_field_value",
         "command.payment.sender.status.status",
         "expect one of \\['none', 'needs_kyc_data', 'ready_for_settlement', 'abort', 'soft_match'\\], but got: invalid",
     )
@@ -384,7 +384,7 @@ def test_invalid_uuid_field_value():
     request_json = set_field(sample_request_json(), {"cid": "invalid"})
     assert_field_error(
         request_json,
-        "invalid-field-value",
+        "invalid_field_value",
         "cid",
         "invalid does not match pattern",
     )
@@ -392,7 +392,7 @@ def test_invalid_uuid_field_value():
     request_json = set_field(sample_request_json(), {"command.payment.reference_id": "invalid"})
     assert_field_error(
         request_json,
-        "invalid-field-value",
+        "invalid_field_value",
         "command.payment.reference_id",
         "invalid does not match pattern",
     )
@@ -401,7 +401,7 @@ def test_invalid_uuid_field_value():
 
     assert_field_error(
         request_json,
-        "invalid-field-value",
+        "invalid_field_value",
         "command.payment.original_payment_reference_id",
         "invalid does not match pattern",
     )
@@ -417,7 +417,7 @@ def test_unknown_field():
     )
     assert_field_error(
         request_json,
-        "unknown-field",
+        "unknown_field",
         "command.payment.sender.status.unknown-field-1",
         "command.payment.sender.status: unknown-field-1, unknown-field-2",
     )
@@ -427,7 +427,7 @@ def test_missing_required_field():
     request_json = set_field(sample_request_json(), {"command.payment.sender.status.status": None})
     assert_field_error(
         request_json,
-        "missing-field",
+        "missing_field",
         "command.payment.sender.status.status",
         "missing field: command.payment.sender.status.status",
     )


### PR DESCRIPTION
Other enum values like status are using underscore for multi-words values. This PR changes error code to use underscore too.