### PR TITLE
change to not use f-string for formatting string with text

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name="diem",
-    version="1.2.0",
+    version="1.2.1",
     description="The Python Client SDK for Diem",
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/src/diem/offchain/jws.py
+++ b/src/diem/offchain/jws.py
@@ -40,7 +40,7 @@ def deserialize_string(msg: bytes) -> typing.Tuple[str, bytes, bytes]:
     text = msg.decode(ENCODING)
     parts = text.split(".")
     if len(parts) != 3:
-        raise ValueError(f"invalid JWS compact message: {text}, expect 3 parts: <header>.<payload>.<signature>")
+        raise ValueError("invalid JWS compact message: %s, expect 3 parts: <header>.<payload>.<signature>" % text)
 
     header, body, sig = parts
     if header.encode(ENCODING) != PROTECTED_HEADER:

--- a/tests/test_offchain_jws.py
+++ b/tests/test_offchain_jws.py
@@ -23,7 +23,9 @@ def test_serialize_deserialize():
 
 
 def test_deserialize_error_if_not_3_parts():
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="invalid JWS compact message: header.payload, expect 3 parts: <header>.<payload>.<signature>"
+    ):
         offchain.jws.deserialize(
             b".".join([b"header", b"payload"]),
             offchain.CommandResponseObject,


### PR DESCRIPTION
For unknown reason, python 3.7 may not render the text substituted.