### PR TITLE
rename error codes according to dip-1

### DIFF
--- a/examples/tests/test_offchain_error_cases.py
+++ b/examples/tests/test_offchain_error_cases.py
@@ -319,11 +319,11 @@ def test_reference_id_uuid(sender_app, receiver_app):
     assert_response_command_error(resp, "invalid_field_value", "command.payment.reference_id")
 
 
-def test_unknown_actor_address_could_not_find_request_receiver_account_id(sender_app, receiver_app):
+def test_unknown_address_could_not_find_request_receiver_account_id(sender_app, receiver_app):
     request = minimum_required_fields_request_sample(sender_app, receiver_app)
     request["command"]["payment"]["receiver"]["address"] = sender_app.offchain_client.my_compliance_key_account_id
     resp = send_request(request, sender_app, receiver_app, "failure")
-    assert_response_command_error(resp, "unknown_actor_address")
+    assert_response_command_error(resp, "unknown_address")
 
 
 def test_x_request_sender_address_must_one_of_actor_addresses(sender_app, receiver_app):
@@ -335,7 +335,7 @@ def test_x_request_sender_address_must_one_of_actor_addresses(sender_app, receiv
         "failure",
         sender_address=sender_app.offchain_client.my_compliance_key_account_id,
     )
-    assert_response_command_error(resp, "invalid_x_request_sender_address")
+    assert_response_command_error(resp, "invalid_http_header")
 
 
 def test_http_header_x_request_sender_address_missing(sender_app, receiver_app):
@@ -352,7 +352,7 @@ def test_could_not_find_onchain_account_by_x_request_sender_address(sender_app, 
     request = minimum_required_fields_request_sample(sender_app, receiver_app)
     request["command"]["payment"]["sender"]["address"] = account_id
     resp = send_request(request, sender_app, receiver_app, "failure", sender_address=account_id)
-    assert_response_protocol_error(resp, "invalid_x_request_sender_address")
+    assert_response_protocol_error(resp, "invalid_http_header")
 
 
 def test_could_not_find_compliance_key_of_x_request_sender_address(sender_app, receiver_app):
@@ -361,7 +361,7 @@ def test_could_not_find_compliance_key_of_x_request_sender_address(sender_app, r
     request = minimum_required_fields_request_sample(sender_app, receiver_app)
     request["command"]["payment"]["sender"]["address"] = account_id
     resp = send_request(request, sender_app, receiver_app, "failure", sender_address=account_id)
-    assert_response_protocol_error(resp, "invalid_x_request_sender_address")
+    assert_response_protocol_error(resp, "invalid_http_header")
 
 
 def test_invalid_recipient_signature(sender_app, receiver_app):

--- a/src/diem/offchain/client.py
+++ b/src/diem/offchain/client.py
@@ -151,7 +151,7 @@ class Client:
         try:
             _, public_key = self.get_base_url_and_compliance_key(request_sender_address)
         except ValueError as e:
-            raise protocol_error(ErrorCode.invalid_x_request_sender_address, str(e)) from e
+            raise protocol_error(ErrorCode.invalid_http_header, str(e)) from e
 
         request = _deserialize_jws(request_bytes, CommandRequestObject, public_key, command_error)
         if request.command_type == CommandType.PaymentCommand:
@@ -218,7 +218,7 @@ class Client:
     def validate_request_sender_address(self, request_sender_address: str, addresses: typing.List[str]) -> None:
         if request_sender_address not in addresses:
             raise command_error(
-                ErrorCode.invalid_x_request_sender_address,
+                ErrorCode.invalid_http_header,
                 f"address {request_sender_address} is not one of {addresses}",
             )
 
@@ -228,7 +228,7 @@ class Client:
         if self.is_my_account_id(obj.receiver.address):
             return PaymentCommand(cid=cid, my_actor_address=obj.receiver.address, payment=obj, inbound=True)
 
-        raise command_error(ErrorCode.unknown_actor_address, "unknown actor addresses: {obj}")
+        raise command_error(ErrorCode.unknown_address, "unknown actor addresses: {obj}")
 
     def is_my_account_id(self, account_id: str) -> bool:
         account_address, _ = identifier.decode_account(account_id, self.hrp)

--- a/src/diem/offchain/types/command_types.py
+++ b/src/diem/offchain/types/command_types.py
@@ -60,19 +60,19 @@ class ErrorCode:
 
     # 1. could not find actor's onchain account by address
     # 2. none of actor addresses is server's (parent / child) vasp or dd address
-    unknown_actor_address = "unknown_actor_address"
+    unknown_address = "unknown_address"
 
     # overwrite write once / immutable field value
     invalid_overwrite = "invalid_overwrite"
 
     # could not find command by reference_id for a non-initial command
     invalid_initial_or_prior_not_found = "invalid_initial_or_prior_not_found"
-    invalid_x_request_sender_address = "invalid_x_request_sender_address"
 
     # the command is conflict with another command updating in progress by reference id
     conflict = "conflict"
 
     missing_http_header = "missing_http_header"
+    invalid_http_header = "invalid_http_header"
     invalid_recipient_signature = "invalid_recipient_signature"
 
 


### PR DESCRIPTION
1. unknown_actor_address to unknown_address
2. invalid_x_request_sender_address to invalid_http_header