### PR TITLE
Use ceil of the calculated exchanged xdx amount for checking under the limit

### DIFF
--- a/examples/tests/test_offchain_error_cases.py
+++ b/examples/tests/test_offchain_error_cases.py
@@ -292,7 +292,7 @@ def test_resource_is_locked_error(sender_app, receiver_app):
 
 
 def test_travel_rule_limit_validation(sender_app, receiver_app):
-    request = minimum_required_fields_request_sample(sender_app, receiver_app, 10)
+    request = minimum_required_fields_request_sample(sender_app, receiver_app, amount=10)
 
     resp = send_request(request, sender_app, receiver_app, "failure")
     assert_response_command_error(resp, "no_kyc_needed", "command.payment.action.amount")

--- a/tests/test_offchain_client.py
+++ b/tests/test_offchain_client.py
@@ -23,3 +23,10 @@ def test_send_and_deserialize_request(factory):
     command = offchain.PaymentCommand(payment=payment, my_actor_address=payment.sender.address, inbound=False)
     resp = sender_client.send_command(command, sender.compliance_key.sign)
     assert resp
+
+
+def test_is_under_the_threshold():
+    assert offchain.client._is_under_the_threshold(2, 0.2, 1)
+    assert offchain.client._is_under_the_threshold(2, 0.2, 5)
+    assert not offchain.client._is_under_the_threshold(2, 0.2, 6)
+    assert not offchain.client._is_under_the_threshold(2, 0.2, 10)


### PR DESCRIPTION
 As it involves float point converting, relax this validation to avoid rounding difference comparing with the Diem Move VM validation logic.