### PR TITLE
improve LocalAccount and testnet utils

### DIFF
--- a/examples/refund.py
+++ b/examples/refund.py
@@ -33,11 +33,7 @@ def test_refund_transaction_of_custodial_to_custodial_under_threshold():
     )
 
     sender = sender_custodial.available_child_vasp()
-    txn = sender_custodial.create_transaction(sender, script, intent.currency_code)
-
-    signed_txn = sender.sign(txn)
-    client.submit(signed_txn)
-    executed_txn = client.wait_for_transaction(signed_txn)
+    executed_txn = sender.submit_and_wait_for_txn(client, script)
 
     # start to refund the transaction
 
@@ -60,6 +56,5 @@ def test_refund_transaction_of_custodial_to_custodial_under_threshold():
 
     # receiver is sender of refund txn
     sender = receiver_custodial.available_child_vasp()
-    txn = receiver_custodial.create_transaction(sender, refund_txn_script, currency_code)
-    refund_executed_txn = receiver_custodial.submit_and_wait(sender.sign(txn))
+    refund_executed_txn = sender.submit_and_wait_for_txn(client, refund_txn_script)
     assert refund_executed_txn is not None

--- a/examples/stubs.py
+++ b/examples/stubs.py
@@ -64,9 +64,7 @@ class CustodialApp:
         self._users.append(identifier.gen_subaddress())
 
     def payment(self, user_id: int, amount: int) -> str:
-        account_id = identifier.encode_account(
-            self._children[0].account_address, self._users[user_id], identifier.TDM  # testnet HRP
-        )
+        account_id = self._children[0].account_identifier(self._users[user_id])
         return identifier.encode_intent(account_id, testnet.TEST_CURRENCY_CODE, amount)
 
     # TODO: change to generate sub address for user when needed

--- a/examples/tests/test_offchain_error_cases.py
+++ b/examples/tests/test_offchain_error_cases.py
@@ -10,7 +10,7 @@ from diem.offchain import (
     CommandResponseError,
     PaymentActionObject,
 )
-from diem import LocalAccount, identifier, testnet
+from diem import LocalAccount, testnet
 from ..vasp.wallet import ActionResult
 import dataclasses, requests, json, copy, pytest, uuid
 
@@ -363,7 +363,7 @@ def test_missing_x_request_id(sender_app, receiver_app):
 
 def test_could_not_find_onchain_account_by_x_request_sender_address(sender_app, receiver_app):
     account = LocalAccount.generate()
-    account_id = identifier.encode_account(account.account_address, None, sender_app.hrp)
+    account_id = account.account_identifier()
     request = minimum_required_fields_request_sample(sender_app, receiver_app)
     request["command"]["payment"]["sender"]["address"] = account_id
     resp = send_request(request, sender_app, receiver_app, "failure", sender_address=account_id)
@@ -372,7 +372,7 @@ def test_could_not_find_onchain_account_by_x_request_sender_address(sender_app, 
 
 def test_could_not_find_compliance_key_of_x_request_sender_address(sender_app, receiver_app):
     account = testnet.gen_account(testnet.create_client())
-    account_id = identifier.encode_account(account.account_address, None, sender_app.hrp)
+    account_id = account.account_identifier()
     request = minimum_required_fields_request_sample(sender_app, receiver_app)
     request["command"]["payment"]["sender"]["address"] = account_id
     resp = send_request(request, sender_app, receiver_app, "failure", sender_address=account_id)
@@ -535,8 +535,7 @@ def send_request_json(
     if sender_address is None:
         subaddresses = sender_app.users["foo"].subaddresses
         subaddress = subaddresses[len(subaddresses) - 1] if len(subaddresses) > 0 else None
-        account_address = sender_app._available_child_vasp().account_address
-        sender_address = identifier.encode_account(account_address, subaddress, sender_app.hrp)
+        sender_address = sender_app._available_child_vasp().account_identifier(subaddress)
     return send_request_json_with_headers(
         request_json,
         sender_app,

--- a/examples/vasp/wallet.py
+++ b/examples/vasp/wallet.py
@@ -60,7 +60,7 @@ class WalletApp:
         """generate a WalletApp running on testnet"""
 
         offchain_service_port = offchain.http_server.get_available_port()
-        account = testnet.gen_vasp_account(client, f"http://localhost:{offchain_service_port}")
+        account = testnet.gen_account(client, base_url=f"http://localhost:{offchain_service_port}")
         w = WalletApp(
             name=name,
             jsonrpc_client=client,
@@ -208,9 +208,8 @@ class WalletApp:
         command = typing.cast(offchain.PaymentCommand, command)
         child_vasp = self._find_child_vasp(command.sender_account_address(self.hrp))
         assert command.payment.recipient_signature
-        testnet.exec_txn(
+        child_vasp.submit_and_wait_for_txn(
             self.jsonrpc_client,
-            child_vasp,
             stdlib.encode_peer_to_peer_with_metadata_script(
                 currency=utils.currency_code(command.payment.action.currency),
                 payee=command.receiver_account_address(self.hrp),

--- a/examples/vasp/wallet.py
+++ b/examples/vasp/wallet.py
@@ -337,7 +337,7 @@ class WalletApp:
     def gen_user_account_id(self, user_name: str) -> str:
         subaddress = identifier.gen_subaddress()
         self.users[user_name].subaddresses.append(subaddress)
-        return identifier.encode_account(self._available_child_vasp().account_address, subaddress, self.hrp)
+        return self._available_child_vasp().account_identifier(subaddress)
 
     # ---------------------- child vasps ---------------------------
 

--- a/src/diem/local_account.py
+++ b/src/diem/local_account.py
@@ -7,17 +7,22 @@ LocalAccount provides operations we need for creating auth key, account address 
 raw transaction.
 """
 
-from . import (
-    diem_types,
-    utils,
-)
+from . import diem_types, jsonrpc, utils, stdlib
+from .serde_types import uint64
 
 from .auth_key import AuthKey
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey, Ed25519PublicKey
+from typing import Dict
+from dataclasses import dataclass, field
+from copy import copy
+import time
 
 
+@dataclass
 class LocalAccount:
     """LocalAccount is like a wallet account
+
+    Some default values are initialized for testnet.
 
     WARN: This is handy class for creating tests for your application, but may not ideal for your
     production code, because it uses a specific implementaion of ed25519 and requires loading your
@@ -31,19 +36,35 @@ class LocalAccount:
     def generate() -> "LocalAccount":
         """Generate a random private key and initialize local account"""
 
-        private_key = Ed25519PrivateKey.generate()
-        return LocalAccount(private_key)
+        return LocalAccount()
 
     @staticmethod
     def from_private_key_hex(key: str) -> "LocalAccount":
-        return LocalAccount(Ed25519PrivateKey.from_private_bytes(bytes.fromhex(key)))
+        return LocalAccount.from_dict({"private_key": key})
 
-    private_key: Ed25519PrivateKey
-    compliance_key: Ed25519PrivateKey
+    @staticmethod
+    def from_dict(dic: Dict[str, str]) -> "LocalAccount":
+        """from a dict that is created by LocalAccount#to_dict
 
-    def __init__(self, private_key: Ed25519PrivateKey) -> None:
-        self.private_key = private_key
-        self.compliance_key = Ed25519PrivateKey.generate()
+        The private_key and compliance_key values are hex-encoded bytes; they will
+        be loaded by `Ed25519PrivateKey.from_private_bytes`.
+        """
+
+        dic = copy(dic)
+        for name in ["private_key", "compliance_key"]:
+            if name not in dic:
+                continue
+            key = dic[name]
+            dic[name] = Ed25519PrivateKey.from_private_bytes(bytes.fromhex(key))
+        return LocalAccount(**dic)  # pyre-ignore
+
+    private_key: Ed25519PrivateKey = field(default_factory=Ed25519PrivateKey.generate)
+    compliance_key: Ed25519PrivateKey = field(default_factory=Ed25519PrivateKey.generate)
+
+    txn_gas_currency_code: str = field(default="XDX")
+    txn_max_gas_amount: int = field(default=1_000_000)
+    txn_gas_unit_price: int = field(default=0)
+    txn_expire_duration_secs: int = field(default=30)
 
     @property
     def auth_key(self) -> AuthKey:
@@ -70,3 +91,47 @@ class LocalAccount:
 
         signature = self.private_key.sign(utils.raw_transaction_signing_msg(txn))
         return utils.create_signed_transaction(txn, self.public_key_bytes, signature)
+
+    def create_txn(self, client: jsonrpc.Client, script: diem_types.Script) -> diem_types.SignedTransaction:
+        sequence_number = client.get_account_sequence(self.account_address)
+        chain_id = client.get_last_known_state().chain_id
+        return self.sign(
+            diem_types.RawTransaction(  # pyre-ignore
+                sender=self.account_address,
+                sequence_number=uint64(sequence_number),
+                payload=diem_types.TransactionPayload__Script(value=script),
+                max_gas_amount=uint64(self.txn_max_gas_amount),
+                gas_unit_price=uint64(self.txn_gas_unit_price),
+                gas_currency_code=self.txn_gas_currency_code,
+                expiration_timestamp_secs=uint64(int(time.time()) + self.txn_expire_duration_secs),
+                chain_id=diem_types.ChainId.from_int(chain_id),
+            )
+        )
+
+    def submit_txn(self, client: jsonrpc.Client, script: diem_types.Script) -> diem_types.SignedTransaction:
+        txn = self.create_txn(client, script)
+        client.submit(txn)
+        return txn
+
+    def submit_and_wait_for_txn(self, client: jsonrpc.Client, script: diem_types.Script) -> jsonrpc.Transaction:
+        txn = self.submit_txn(client, script)
+        return client.wait_for_transaction(txn, timeout_secs=self.txn_expire_duration_secs)
+
+    def rotate_dual_attestation_info(self, client: jsonrpc.Client, base_url: str) -> jsonrpc.Transaction:
+        return self.submit_and_wait_for_txn(
+            client,
+            stdlib.encode_rotate_dual_attestation_info_script(
+                new_url=base_url.encode("utf-8"), new_key=self.compliance_public_key_bytes
+            ),
+        )
+
+    def to_dict(self) -> Dict[str, str]:
+        """export to a string only dictionary for saving and importing as config
+
+        private keys will be exported as hex-encded raw key bytes.
+        """
+
+        d = copy(self.__dict__)
+        d["private_key"] = utils.private_key_bytes(self.private_key).hex()
+        d["compliance_key"] = utils.private_key_bytes(self.compliance_key).hex()
+        return d

--- a/src/diem/local_account.py
+++ b/src/diem/local_account.py
@@ -7,12 +7,12 @@ LocalAccount provides operations we need for creating auth key, account address 
 raw transaction.
 """
 
-from . import diem_types, jsonrpc, utils, stdlib
+from . import diem_types, jsonrpc, utils, stdlib, identifier
 from .serde_types import uint64
 
 from .auth_key import AuthKey
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey, Ed25519PublicKey
-from typing import Dict
+from typing import Dict, Optional
 from dataclasses import dataclass, field
 from copy import copy
 import time
@@ -61,6 +61,7 @@ class LocalAccount:
     private_key: Ed25519PrivateKey = field(default_factory=Ed25519PrivateKey.generate)
     compliance_key: Ed25519PrivateKey = field(default_factory=Ed25519PrivateKey.generate)
 
+    hrp: str = field(default=identifier.TDM)
     txn_gas_currency_code: str = field(default="XDX")
     txn_max_gas_amount: int = field(default=1_000_000)
     txn_gas_unit_price: int = field(default=0)
@@ -85,6 +86,9 @@ class LocalAccount:
     @property
     def compliance_public_key_bytes(self) -> bytes:
         return utils.public_key_bytes(self.compliance_key.public_key())
+
+    def account_identifier(self, subaddress: Optional[bytes] = None) -> str:
+        return identifier.encode_account(self.account_address, subaddress, self.hrp)
 
     def sign(self, txn: diem_types.RawTransaction) -> diem_types.SignedTransaction:
         """Create signed transaction for given raw transaction"""

--- a/src/diem/offchain/client.py
+++ b/src/diem/offchain/client.py
@@ -50,7 +50,7 @@ class Client:
     >>> from diem import offchain, jsonrpc, testnet, LocalAccount
     >>>
     >>> jsonrpc_client = testnet.create_client()
-    >>> account = testnet.gen_vasp_account(client, "http://vasp.com/offchain")
+    >>> account = testnet.gen_account(client, base_url="http://vasp.com/offchain")
     >>> compliance_key_account_address = account.account_address
     >>> client = offchain.Client(compliance_key_account_address, jsonrpc_client, identifier.TDM)
     ```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,18 +21,14 @@ class Factory:
     def new_payment_object(self, sender=LocalAccount.generate(), receiver=LocalAccount.generate()):
         amount = 1_000_000_000_000
         currency = testnet.TEST_CURRENCY_CODE
-        sender_account_id = identifier.encode_account(sender.account_address, identifier.gen_subaddress(), self.hrp())
+        sender_account_id = sender.account_identifier(identifier.gen_subaddress())
         sender_kyc_data = offchain.individual_kyc_data(
             given_name="Jack",
             surname="G",
             address=offchain.AddressObject(city="San Francisco"),
         )
 
-        receiver_account_id = identifier.encode_account(
-            receiver.account_address,
-            identifier.gen_subaddress(),
-            self.hrp(),
-        )
+        receiver_account_id = receiver.account_identifier(identifier.gen_subaddress())
 
         return offchain.new_payment_object(
             sender_account_id,

--- a/tests/test_local_account.py
+++ b/tests/test_local_account.py
@@ -9,3 +9,34 @@ def test_from_private_key_hex():
     hex_key = utils.private_key_bytes(account.private_key).hex()
     new_account = LocalAccount.from_private_key_hex(hex_key)
     assert utils.private_key_bytes(new_account.private_key).hex() == hex_key
+
+
+def test_from_and_to_dict():
+    config = {
+        "private_key": "ab70ae3aa603641f049a3356927d0ba836f775e862f559073a6281782479fd1e",
+        "compliance_key": "f75b74a94250bda7abfab2045205e05c56e5dcba24ecea6aff75aac9463cdc2f",
+        "hrp": "tdm",
+        "txn_gas_currency_code": "XDX",
+        "txn_max_gas_amount": 1000000,
+        "txn_gas_unit_price": 0,
+        "txn_expire_duration_secs": 30,
+    }
+    account = LocalAccount.from_dict(config)
+    assert account.to_dict() == config
+
+
+def test_generate_keys():
+    account = LocalAccount()
+    sig1 = account.private_key.sign(b"test")
+    sig2 = account.compliance_key.sign(b"test")
+
+    load_account = LocalAccount.from_dict(account.to_dict())
+    assert sig1 == load_account.private_key.sign(b"test")
+    assert sig2 == load_account.compliance_key.sign(b"test")
+
+
+def test_from_dict_generate_keys():
+    account = LocalAccount.from_dict({})
+    assert account
+    assert account.private_key
+    assert account.compliance_key

--- a/tests/test_local_account.py
+++ b/tests/test_local_account.py
@@ -1,7 +1,7 @@
 # Copyright (c) The Diem Core Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from diem import utils, LocalAccount
+from diem import identifier, utils, LocalAccount
 
 
 def test_from_private_key_hex():
@@ -40,3 +40,12 @@ def test_from_dict_generate_keys():
     assert account
     assert account.private_key
     assert account.compliance_key
+
+
+def test_account_identifier():
+    account = LocalAccount()
+    assert account.account_identifier() == identifier.encode_account(account.account_address, None, account.hrp)
+    subaddress = identifier.gen_subaddress()
+    assert account.account_identifier(subaddress) == identifier.encode_account(
+        account.account_address, subaddress, account.hrp
+    )

--- a/tests/test_offchain_client.py
+++ b/tests/test_offchain_client.py
@@ -7,8 +7,8 @@ from diem import offchain, testnet
 def test_send_and_deserialize_request(factory):
     client = testnet.create_client()
     receiver_port = offchain.http_server.get_available_port()
-    sender = testnet.gen_vasp_account(client, "http://localhost:8888")
-    receiver = testnet.gen_vasp_account(client, f"http://localhost:{receiver_port}")
+    sender = testnet.gen_account(client, base_url="http://localhost:8888")
+    receiver = testnet.gen_account(client, base_url=f"http://localhost:{receiver_port}")
     sender_client = factory.create_offchain_client(sender, client)
     receiver_client = factory.create_offchain_client(receiver, client)
 

--- a/tests/test_testnet.py
+++ b/tests/test_testnet.py
@@ -122,7 +122,7 @@ def test_get_account_transaction_by_hex_encoded_account_address():
 
 def test_get_account_transaction_include_events():
     client = testnet.create_client()
-    account = testnet.gen_vasp_account(client, "http://baseurl")
+    account = testnet.gen_account(client, base_url="http://baseurl")
 
     txn = client.get_account_transaction(account.account_address, 0, include_events=True)
     assert txn is not None
@@ -164,7 +164,7 @@ def test_get_account_transactions_by_hex_encoded_account_address():
 
 def test_get_account_transactions_with_events():
     client = testnet.create_client()
-    account = testnet.gen_vasp_account(client, "url")
+    account = testnet.gen_account(client, base_url="url")
     txns = client.get_account_transactions(account.account_address, 0, 1, include_events=True)
     assert txns is not None
     assert isinstance(txns, list)
@@ -339,9 +339,9 @@ def test_get_parent_vasp_account_with_non_vasp_account_address():
         client.get_parent_vasp_account(utils.TREASURY_ADDRESS)
 
 
-def test_gen_vasp_account():
+def test_gen_account():
     client = testnet.create_client()
-    account = testnet.gen_vasp_account(client, "http://hello.com")
+    account = testnet.gen_account(client, base_url="http://hello.com")
     child_vasp = testnet.gen_child_vasp(client, account)
 
     assert client.get_account(account.account_address).role.type == "parent_vasp"
@@ -351,7 +351,7 @@ def test_gen_vasp_account():
 def test_get_base_url_and_compliance_key():
     client = testnet.create_client()
 
-    parent_vasp = testnet.gen_vasp_account(client, "http://hello.com")
+    parent_vasp = testnet.gen_account(client, base_url="http://hello.com")
     child_vasp = testnet.gen_child_vasp(client, parent_vasp)
 
     base_url, key = client.get_base_url_and_compliance_key(child_vasp.account_address)


### PR DESCRIPTION
1. export to dict and import from dict: this way, we can write the LocalAccount as config into config file.
2. moved some testnet utils functions into LocalAccount as generic utils:
    1. create transaction from a script
    2. submit and wait for transaction executed
    3. config transaction fields: gas currency code, max gas amount, gas
unit price and expire duration.
3. merged testnet gen_vasp_account and gen_account
4. add hrp to LocalAccount to simplify encoding account identifier for the account address