### PR TITLE
re-organize tests for creating test account

### DIFF
--- a/src/diem/testing/miniwallet/client.py
+++ b/src/diem/testing/miniwallet/client.py
@@ -81,7 +81,7 @@ class AccountResource:
     kyc_data: str
 
     def balance(self, currency: str) -> int:
-        return self.balances().get(currency, 0)
+        return self._balances().get(currency, 0)
 
     def send_payment(self, currency: str, amount: int, payee: str) -> Payment:
         p = self.client.create(self._resources("payment"), payee=payee, currency=currency, amount=amount)
@@ -89,9 +89,6 @@ class AccountResource:
 
     def create_payment_uri(self) -> PaymentUri:
         return PaymentUri(**self.client.create(self._resources("payment_uri")))
-
-    def balances(self) -> Dict[str, int]:
-        return self.client.get(self._resources("balance"))
 
     def events(self, start: int = 0) -> List[Event]:
         ret = self.client.send("GET", self._resources("event")).json()
@@ -137,6 +134,15 @@ class AccountResource:
 
     def info(self, *args: Any, **kwargs: Any) -> None:
         self.client.logger.info(*args, **kwargs)
+
+    def _balances(self) -> Dict[str, int]:
+        """returns account balances object
+
+        should always prefer to use func `balance(currency) -> int`, which returns zero
+        when currency not exist in the response.
+        """
+
+        return self.client.get(self._resources("balance"))
 
     def _resources(self, resource: str) -> str:
         return "/accounts/%s/%ss" % (self.id, resource)

--- a/src/diem/testing/suites/test_create_test_account.py
+++ b/src/diem/testing/suites/test_create_test_account.py
@@ -1,0 +1,82 @@
+# Copyright (c) The Diem Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from diem import offchain
+from diem.testing.miniwallet import RestClient
+import pytest, requests, json
+
+
+def test_create_a_blank_account(target_client: RestClient) -> None:
+    account = target_client.create_account()
+    assert account.id
+    assert account.kyc_data is None
+    assert account.balances() == {}
+
+
+@pytest.mark.parametrize("amount", [0, 1, 100, 10000000000])
+@pytest.mark.parametrize("currency", ["XUS"])
+def test_create_an_account_with_initial_deposit_balances(target_client: RestClient, currency: str, amount: int) -> None:
+    account = target_client.create_account(kyc_data=None, balances={currency: amount})
+    assert account.id
+    assert account.kyc_data is None
+    assert account.balances() == {currency: amount}
+
+
+@pytest.mark.parametrize(  # pyre-ignore
+    "kyc_data",
+    [
+        offchain.to_json(offchain.individual_kyc_data()),
+        offchain.to_json(offchain.entity_kyc_data()),
+    ],
+)
+def test_create_an_account_with_minimum_valid_kyc_data(target_client: RestClient, kyc_data: str) -> None:
+    account = target_client.create_account(kyc_data=kyc_data)
+    assert account.id
+    assert account.kyc_data == kyc_data
+
+
+def test_create_an_account_with_valid_kyc_data_and_initial_deposit_balances(
+    target_client: RestClient, currency: str
+) -> None:
+    minimum_kyc_data = offchain.to_json(offchain.individual_kyc_data())
+    account = target_client.create_account(kyc_data=minimum_kyc_data, balances={currency: 123})
+    assert account.id
+    assert account.kyc_data == minimum_kyc_data
+
+
+@pytest.mark.parametrize(
+    "kyc_data",
+    [
+        "invalid json",
+        '{"type": "individual"}',
+        '{"type": "entity"}',
+        '{"payload_version": 1}',
+        '{"type": "individual", "payload_version": "1"}',
+    ],
+)
+def test_create_an_account_with_invalid_kyc_data(target_client: RestClient, kyc_data: str) -> None:
+    with pytest.raises(requests.exceptions.HTTPError, match="400 Client Error"):
+        target_client.create("/accounts", kyc_data=kyc_data)
+
+
+@pytest.mark.parametrize(
+    "balances",
+    [
+        '{"XUS": -1}',
+        '{"DDD": 100}',
+        '{"XUS": 100, "DDD": 100}',
+        '{"XUS": 100, "DDD": -1}',
+        '{"XUS": "100"}',
+        '{"currency": "XUS", "amount": 123}',
+    ],
+)
+def test_create_an_account_with_invalid_initial_deposit_balance_currency(
+    target_client: RestClient, balances: str
+) -> None:
+    with pytest.raises(requests.exceptions.HTTPError, match="400 Client Error"):
+        target_client.create("/accounts", balances=json.loads(balances))
+
+
+def test_account_id_should_be_unique(target_client: RestClient) -> None:
+    ids = [target_client.create_account().id for _ in range(10)]
+    assert sorted(ids) == sorted(list(set(ids)))

--- a/tests/miniwallet/conftest.py
+++ b/tests/miniwallet/conftest.py
@@ -1,0 +1,20 @@
+# Copyright (c) The Diem Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+
+from diem import jsonrpc, testnet
+from diem.testing.miniwallet import RestClient, AppConfig
+import pytest
+
+
+@pytest.fixture(scope="package")
+def target_client(diem_client: jsonrpc.Client) -> RestClient:
+    conf = AppConfig(name="target-wallet")
+    print("launch target app with config %s" % conf)
+    conf.start(diem_client)
+    return conf.create_client()
+
+
+@pytest.fixture(scope="package")
+def diem_client() -> jsonrpc.Client:
+    return testnet.create_client()

--- a/tests/miniwallet/test_api.py
+++ b/tests/miniwallet/test_api.py
@@ -1,0 +1,42 @@
+# Copyright (c) The Diem Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from diem.testing.miniwallet import RestClient
+import pytest, requests, json
+
+
+@pytest.mark.parametrize(
+    "kyc_data",
+    [
+        "invalid json",
+        '{"type": "individual"}',
+        '{"type": "entity"}',
+        '{"payload_version": 1}',
+        '{"type": "individual", "payload_version": "1"}',
+    ],
+)
+def test_create_an_account_with_invalid_kyc_data(target_client: RestClient, kyc_data: str) -> None:
+    with pytest.raises(requests.exceptions.HTTPError, match="400 Client Error") as einfo:
+        target_client.create("/accounts", kyc_data=kyc_data)
+
+    assert "'kyc_data' must be JSON-encoded KycDataObject" in einfo.value.response.text
+
+
+@pytest.mark.parametrize(
+    "balances, err_msg",
+    [
+        ('{"XUS": -1}', "'amount' value must be greater than or equal to zero"),
+        ('{"DDD": 100}', "'currency' is invalid"),
+        ('{"XUS": 100, "DDD": 100}', "'currency' is invalid"),
+        ('{"XUS": 100, "DDD": -1}', "'currency' is invalid"),
+        ('{"XUS": "100"}', "'amount' type must be 'int'"),
+        ('{"currency": "XUS", "amount": 123}', "'currency' is invalid"),
+    ],
+)
+def test_create_an_account_with_invalid_initial_deposit_balance_currency(
+    target_client: RestClient, balances: str, err_msg
+) -> None:
+    with pytest.raises(requests.exceptions.HTTPError, match="400 Client Error") as einfo:
+        target_client.create("/accounts", balances=json.loads(balances))
+
+    assert err_msg in einfo.value.response.text


### PR DESCRIPTION
1. standalone test file for all tests related to creating test account.
2. for clear names for each test cases.
3. split clients setup into multiple fixture functions, so that we don't need start stub client if only run tests that are not required a stub wallet.
4. moved create account with invalid data tests into python sdk miniwallet test suites.