### PR TITLE
Add host/port option for identifying source MW during test

### DIFF
--- a/mini-wallet.md
+++ b/mini-wallet.md
@@ -87,21 +87,32 @@ dmw test --help
 Usage: dmw test [OPTIONS]
 
 Options:
-  -t, --target TEXT             Target mini-wallet application URL.  [default:
-                                http://localhost:8888]
+  -t, --target TEXT               Target mini-wallet application URL.
+                                  [default: http://localhost:8888]
 
-  -j, --jsonrpc TEXT            Diem fullnode JSON-RPC URL.  [default:
-                                http://testnet.diem.com/v1]
+  -h, --stub-bind-host TEXT       The host the miniwallet stub server will
+                                  bind to  [default: localhost]
 
-  -f, --faucet TEXT             Testnet faucet URL.  [default:
-                                http://testnet.diem.com/mint]
+  -p, --stub-bind-port INTEGER    The port the miniwallet stub server will
+                                  bind to. Random if empty.
 
-  --pytest-args TEXT            Additional pytest arguments, split by empty
-                                space, e.g. `--pytest-args '-v -s'`.
+  -u, --stub-diem-account-base-url TEXT
+                                  The address that will be used for offchain
+                                  callbacks. Defaults to
+                                  http://localhost:{random_port}
 
-  -d, --test-debug-api BOOLEAN  Run tests for debug APIs.  [default: False]
-  -v, --verbose BOOLEAN         Enable verbose log output.  [default: False]
-  --help                        Show this message and exit.
+  -j, --jsonrpc TEXT              Diem fullnode JSON-RPC URL.  [default:
+                                  http://testnet.diem.com/v1]
+
+  -f, --faucet TEXT               Testnet faucet URL.  [default:
+                                  http://testnet.diem.com/mint]
+
+  --pytest-args TEXT              Additional pytest arguments, split by empty
+                                  space, e.g. `--pytest-args '-v -s'`.
+
+  -d, --test-debug-api BOOLEAN    Run tests for debug APIs.  [default: False]
+  -v, --verbose                   Enable verbose log output.  [default: False]
+  --help                          Show this message and exit.
 ```
 
 ### How it works

--- a/src/diem/__VERSION__.py
+++ b/src/diem/__VERSION__.py
@@ -1,4 +1,4 @@
 # Copyright (c) The Diem Core Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-VERSION = "1.2.9"
+VERSION = "1.2.10"

--- a/src/diem/testing/miniwallet/__init__.py
+++ b/src/diem/testing/miniwallet/__init__.py
@@ -3,4 +3,4 @@
 
 from .app import App, Account, Transaction, PaymentUri, Event, Payment, PaymentCommand, KycSample, falcon_api
 from .client import RestClient, AccountResource
-from .config import AppConfig
+from .config import AppConfig, ServerConfig

--- a/src/diem/testing/suites/conftest.py
+++ b/src/diem/testing/suites/conftest.py
@@ -3,10 +3,15 @@
 
 
 from ... import testnet, jsonrpc
-from ..miniwallet import RestClient, AppConfig, AccountResource
+from ..miniwallet import RestClient, AppConfig, AccountResource, ServerConfig
 from ..miniwallet.app.event_puller import PENDING_INBOUND_ACCOUNT_ID
 from .clients import Clients
-from .envs import target_url, is_self_check, should_test_debug_api
+from .envs import (
+    target_url,
+    is_self_check,
+    should_test_debug_api,
+    dmw_stub_server,
+)
 import pytest
 
 
@@ -30,7 +35,7 @@ def diem_client() -> jsonrpc.Client:
 
 @pytest.fixture(scope="package")
 def stub_config() -> AppConfig:
-    return AppConfig(name="stub-wallet", enable_debug_api=True)
+    return AppConfig(name="stub-wallet", enable_debug_api=True, server_conf=ServerConfig(**dmw_stub_server()))
 
 
 @pytest.fixture(scope="package")

--- a/src/diem/testing/suites/envs.py
+++ b/src/diem/testing/suites/envs.py
@@ -2,11 +2,42 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from os import getenv, environ
+from typing import Optional, Dict, Any
 
 
 TARGET_URL: str = "DMW_TEST_TARGET"
 TEST_DEBUG_API: str = "DMW_TEST_DEBUG_API"
 SELF_CHECK: str = "DMW_SELF_CHECK"
+
+DMW_STUB_BIND_HOST: str = "DMW_STUB_BIND_HOST"
+DMW_STUB_BIND_PORT: str = "DMW_STUB_BIND_PORT"
+DMW_STUB_DIEM_ACCOUNT_BASE_URL: str = "DMW_STUB_DIEM_ACCOUNT_BASE_URL"
+
+
+def dmw_stub_diem_account_base_url() -> Optional[str]:
+    return getenv(DMW_STUB_DIEM_ACCOUNT_BASE_URL)
+
+
+def dmw_stub_server() -> Dict[str, Any]:
+    return {
+        k: v
+        for k, v in {
+            "host": dmw_stub_bind_host(),
+            "port": dmw_stub_bind_port(),
+            "base_url": dmw_stub_diem_account_base_url(),
+        }.items()
+        if v
+    }
+
+
+def dmw_stub_bind_host() -> Optional[str]:
+    return getenv(DMW_STUB_BIND_HOST)
+
+
+def dmw_stub_bind_port() -> Optional[int]:
+    port = getenv(DMW_STUB_BIND_PORT)
+    if port is not None:
+        return int(port)
 
 
 def target_url() -> str:


### PR DESCRIPTION
add host/port options to MW test startup, so that counterparties can find it at the correct place on chain