### PR TITLE
MiniWallet should refund when received payment with unknown subaddress

### DIFF
--- a/src/diem/local_account.py
+++ b/src/diem/local_account.py
@@ -12,7 +12,7 @@ from .serde_types import uint64
 
 from .auth_key import AuthKey
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey, Ed25519PublicKey
-from typing import Dict, Optional, Tuple
+from typing import Dict, Optional, Tuple, Union
 from dataclasses import dataclass, field
 from copy import copy
 import time
@@ -87,7 +87,7 @@ class LocalAccount:
     def compliance_public_key_bytes(self) -> bytes:
         return utils.public_key_bytes(self.compliance_key.public_key())
 
-    def account_identifier(self, subaddress: Optional[bytes] = None) -> str:
+    def account_identifier(self, subaddress: Union[str, bytes, None] = None) -> str:
         return identifier.encode_account(self.account_address, subaddress, self.hrp)
 
     def decode_account_identifier(self, encoded_id: str) -> Tuple[diem_types.AccountAddress, Optional[bytes]]:

--- a/src/diem/testing/miniwallet/app/diem_account.py
+++ b/src/diem/testing/miniwallet/app/diem_account.py
@@ -3,7 +3,7 @@
 
 from dataclasses import dataclass
 from typing import Tuple
-from .models import Transaction
+from .models import Transaction, RefundReason
 from .... import jsonrpc, identifier, offchain, stdlib, utils, txnmetadata, LocalAccount
 
 
@@ -11,6 +11,9 @@ from .... import jsonrpc, identifier, offchain, stdlib, utils, txnmetadata, Loca
 class DiemAccount:
     account: LocalAccount
     client: jsonrpc.Client
+
+    def refund_metadata(self, version: int, reason: RefundReason) -> Tuple[bytes, bytes]:
+        return (txnmetadata.refund_metadata(version, reason.to_diem_type()), b"")
 
     def general_metadata(self, from_subaddress: bytes, payee: str) -> Tuple[bytes, bytes]:
         to_account, to_subaddress = identifier.decode_account(payee, self.account.hrp)

--- a/src/diem/testing/miniwallet/app/models.py
+++ b/src/diem/testing/miniwallet/app/models.py
@@ -4,7 +4,7 @@
 from dataclasses import dataclass, field, asdict, fields
 from enum import Enum
 from typing import Optional, List, Dict, Any
-from .... import identifier, offchain
+from .... import identifier, offchain, diem_types
 
 
 @dataclass
@@ -78,6 +78,20 @@ class KycSample:
         return any(self.match_kyc_data(f, kyc) for f in fields)
 
 
+class RefundReason(str, Enum):
+    invalid_subaddress = "invalid_subaddress"
+    other = "other"
+
+    @staticmethod
+    def from_diem_type(reason: diem_types.RefundReason) -> "RefundReason":
+        if isinstance(reason, diem_types.RefundReason__InvalidSubaddress):
+            return RefundReason.invalid_subaddress
+        return RefundReason.other
+
+    def to_diem_type(self) -> diem_types.RefundReason:
+        return diem_types.RefundReason__InvalidSubaddress()
+
+
 @dataclass
 class Transaction(Base):
     class Status(str, Enum):
@@ -95,6 +109,8 @@ class Transaction(Base):
     reference_id: Optional[str] = field(default=None)
     signed_transaction: Optional[str] = field(default=None)
     diem_transaction_version: Optional[int] = field(default=None)
+    refund_diem_txn_version: Optional[int] = field(default=None)
+    refund_reason: Optional[RefundReason] = field(default=None)
 
     def subaddress(self) -> bytes:
         return bytes.fromhex(str(self.subaddress_hex))

--- a/src/diem/testing/suites/conftest.py
+++ b/src/diem/testing/suites/conftest.py
@@ -3,7 +3,8 @@
 
 
 from ... import testnet, jsonrpc
-from ..miniwallet import RestClient, AppConfig
+from ..miniwallet import RestClient, AppConfig, AccountResource
+from ..miniwallet.app.event_puller import PENDING_INBOUND_ACCOUNT_ID
 from .clients import Clients
 from .envs import target_url, is_self_check, should_test_debug_api
 import pytest
@@ -62,3 +63,8 @@ def currency() -> str:
 def travel_rule_threshold(clients: Clients) -> int:
     # todo: convert the limit base on currency
     return clients.diem.get_metadata().dual_attestation_limit
+
+
+@pytest.fixture
+def pending_income_account(stub_client: RestClient) -> AccountResource:
+    return AccountResource(id=PENDING_INBOUND_ACCOUNT_ID, client=stub_client)

--- a/src/diem/testing/suites/test_miniwallet_api.py
+++ b/src/diem/testing/suites/test_miniwallet_api.py
@@ -28,14 +28,15 @@ def test_send_payment_and_events(clients: Clients, hrp: str, currency: str) -> N
     receiver.wait_for_balance(currency, amount)
 
     new_events = [e for e in sender.events(index) if e.type != "info"]
-    assert len(new_events) == 4, new_events
+    assert len(new_events) == 5, new_events
     assert new_events[0].type == "created_transaction"
-    assert new_events[1].type == "updated_transaction"
-    assert sorted(list(json.loads(new_events[1].data).keys())) == ["id", "subaddress_hex"]
+    assert new_events[1].type == "created_subaddress"
     assert new_events[2].type == "updated_transaction"
-    assert sorted(list(json.loads(new_events[2].data).keys())) == ["id", "signed_transaction"]
+    assert sorted(list(json.loads(new_events[2].data).keys())) == ["id", "subaddress_hex"]
     assert new_events[3].type == "updated_transaction"
-    assert sorted(list(json.loads(new_events[3].data).keys())) == ["diem_transaction_version", "id", "status"]
+    assert sorted(list(json.loads(new_events[3].data).keys())) == ["id", "signed_transaction"]
+    assert new_events[4].type == "updated_transaction"
+    assert sorted(list(json.loads(new_events[4].data).keys())) == ["diem_transaction_version", "id", "status"]
 
 
 def test_receive_payment_and_events(clients: Clients, currency: str, hrp: str) -> None:

--- a/src/diem/testing/suites/test_receive_payment.py
+++ b/src/diem/testing/suites/test_receive_payment.py
@@ -1,0 +1,62 @@
+# Copyright (c) The Diem Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from diem.testing.miniwallet import RestClient, AccountResource, Transaction
+from diem import identifier
+from typing import Generator
+import pytest
+
+
+amount: int = 123
+
+
+@pytest.fixture
+def sender_account(
+    stub_client: RestClient, currency: str, pending_income_account: AccountResource
+) -> Generator[AccountResource, None, None]:
+    account = stub_client.create_account(balances={currency: amount})
+    yield account
+    account.log_events()
+    # MiniWallet stub saves the payment without account information (subaddress / reference id)
+    # into a pending income account before process it.
+    # Here we log events of the account for showing more context related to the test
+    # when test failed.
+    pending_income_account.log_events()
+
+
+@pytest.fixture
+def receiver_account(target_client: RestClient) -> Generator[AccountResource, None, None]:
+    account = target_client.create_account()
+    yield account
+    account.log_events()
+
+
+def test_receive_payment_with_general_metadata_and_unknown_to_subaddress(
+    sender_account: AccountResource, receiver_account: AccountResource, currency: str, hrp: str
+) -> None:
+    """When received a payment with unknown subaddress, receiver should refund the payment
+    by using RefundMetadata with reason `invalid subaddress`.
+
+    Test Plan:
+    1. Generate a valid payment URI from receiver account.
+    2. Create an invalid payee account identifier by the valid account address and an invalid subaddress.
+    3. Send a payment to the invalid payee.
+    4. Wait for payment completed.
+    5. Assert receiver account does not receive fund.
+    6. Assert sender account balances will has same balances before send the payment eventually.
+    """
+
+    uri = receiver_account.generate_payment_uri()
+    receiver_account_address = uri.intent(hrp).account_address
+    invalid_subaddress = identifier.gen_subaddress()
+    invalid_payee = identifier.encode_account(receiver_account_address, invalid_subaddress, hrp)
+    payment = sender_account.send_payment(currency=currency, amount=amount, payee=invalid_payee)
+    wait_for_payment_transaction_complete(sender_account, payment.id)
+    assert receiver_account.balance(currency) == 0
+    sender_account.wait_for_balance(currency, amount)
+
+
+def wait_for_payment_transaction_complete(account: AccountResource, payment_id: str) -> None:
+    # MiniWallet stub generates `updated_transaction` event when transaction is completed on-chain
+    # Payment id is same with Transaction id.
+    account.wait_for_event("updated_transaction", status=Transaction.Status.completed, id=payment_id)

--- a/tests/test_local_account.py
+++ b/tests/test_local_account.py
@@ -49,6 +49,9 @@ def test_account_identifier():
     assert account.account_identifier(subaddress) == identifier.encode_account(
         account.account_address, subaddress, account.hrp
     )
+    assert account.account_identifier(subaddress.hex()) == identifier.encode_account(
+        account.account_address, subaddress, account.hrp
+    )
 
 
 def test_decode_account_identifier():


### PR DESCRIPTION
1. Refund when subaddress is unknown
2. Creates a refund txn if received a diem txn that has refund metadata
3. Log instead of os._exit when background tasks raised error. (os._exit kills all log and exception details when running test, hence it is not a good idea to just exit.)
4. Created a pending_income_account for parking all invalid payment received funds.
5. Log account and pending_income_account events for context when test failed.
6. Always create a Subaddress entity to link subaddress and account id when creating a new subaddress for transaction, this way we can always find back account id by an onchain metadata subaddress