### PR TITLE
test receive payment with general metadata and invalid to subaddress

### DIFF
--- a/src/diem/__VERSION__.py
+++ b/src/diem/__VERSION__.py
@@ -1,4 +1,4 @@
 # Copyright (c) The Diem Core Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-VERSION = "1.2.10"
+VERSION = "1.2.11"

--- a/src/diem/testing/miniwallet/__init__.py
+++ b/src/diem/testing/miniwallet/__init__.py
@@ -1,6 +1,17 @@
 # Copyright (c) The Diem Core Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from .app import App, Account, Transaction, PaymentUri, Event, Payment, PaymentCommand, KycSample, falcon_api
+from .app import (
+    App,
+    Account,
+    Transaction,
+    PaymentUri,
+    Event,
+    Payment,
+    PaymentCommand,
+    KycSample,
+    RefundReason,
+    falcon_api,
+)
 from .client import RestClient, AccountResource
 from .config import AppConfig, ServerConfig

--- a/src/diem/testing/miniwallet/app/__init__.py
+++ b/src/diem/testing/miniwallet/app/__init__.py
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .app import App
-from .models import Account, Transaction, PaymentUri, Event, KycSample, Payment, PaymentCommand
+from .models import Account, Transaction, PaymentUri, Event, KycSample, Payment, PaymentCommand, RefundReason
 from .falcon import falcon_api

--- a/src/diem/testing/miniwallet/app/event_puller.py
+++ b/src/diem/testing/miniwallet/app/event_puller.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from typing import Dict, Callable, Any
 from .store import InMemoryStore, NotFoundError
 from .models import Transaction, Subaddress, PaymentCommand, RefundReason
-from .... import jsonrpc, diem_types, txnmetadata, identifier
+from .... import jsonrpc, diem_types, txnmetadata, identifier, utils
 
 
 PENDING_INBOUND_ACCOUNT_ID: str = "pending_inbound_account"
@@ -38,38 +38,50 @@ class EventPuller:
             self.fetch(lambda _: None)
 
     def save_payment_txn(self, event: jsonrpc.Event) -> None:
+        try:
+            self._save_payment_txn(event)
+        except (NotFoundError, ValueError) as e:
+            self._create_txn(PENDING_INBOUND_ACCOUNT_ID, event)
+            self.store.create_event(PENDING_INBOUND_ACCOUNT_ID, "info", str(e))
+
+    def _save_payment_txn(self, event: jsonrpc.Event) -> None:
         metadata = txnmetadata.decode_structure(event.data.metadata)
-        if isinstance(metadata, diem_types.GeneralMetadataV0) and metadata.to_subaddress:
+        if isinstance(metadata, diem_types.GeneralMetadataV0):
             try:
-                res = self.store.find(Subaddress, subaddress_hex=metadata.to_subaddress.hex())
-                self._create_txn(res.account_id, event, subaddress_hex=res.subaddress_hex)
+                res = self.store.find(Subaddress, subaddress_hex=utils.hex(metadata.to_subaddress))
+                return self._create_txn(res.account_id, event, subaddress_hex=res.subaddress_hex)
             except NotFoundError:
                 self._create_txn(PENDING_INBOUND_ACCOUNT_ID, event)
                 payee = identifier.encode_account(event.data.sender, metadata.from_subaddress, self.hrp)
-                self.store.create(
-                    Transaction,
-                    account_id=PENDING_INBOUND_ACCOUNT_ID,
-                    status=Transaction.Status.pending,
-                    currency=event.data.amount.currency,
-                    amount=event.data.amount.amount,
-                    payee=payee,
-                    refund_diem_txn_version=event.transaction_version,
-                    refund_reason=RefundReason.invalid_subaddress,
-                )
+                return self._refund(payee, RefundReason.invalid_subaddress, event)
         elif isinstance(metadata, diem_types.TravelRuleMetadataV0) and metadata.off_chain_reference_id:
             cmd = self.store.find(PaymentCommand, reference_id=metadata.off_chain_reference_id)
-            self._create_txn(cmd.account_id, event, reference_id=cmd.reference_id)
+            return self._create_txn(cmd.account_id, event, reference_id=cmd.reference_id)
         elif isinstance(metadata, diem_types.RefundMetadataV0):
             version = int(metadata.transaction_version)
-            txn = self.store.find(Transaction, diem_transaction_version=version)
-            self._create_txn(
-                txn.account_id,
-                event,
-                refund_diem_txn_version=version,
-                refund_reason=RefundReason.from_diem_type(metadata.reason),
-            )
-        else:
-            raise ValueError("unsupported metadata: %s" % metadata)
+            reason = RefundReason.from_diem_type(metadata.reason)
+            diem_txn = self.client.get_transactions(version, 1)[0]
+            if diem_txn.transaction.script and diem_txn.transaction.script.metadata:
+                original_metadata = txnmetadata.decode_structure(diem_txn.transaction.script.metadata)
+                if isinstance(original_metadata, diem_types.GeneralMetadataV0):
+                    original_sender_subaddress = utils.hex(original_metadata.from_subaddress)
+                    sub = self.store.find(Subaddress, subaddress_hex=original_sender_subaddress)
+                    return self._create_txn(
+                        sub.account_id, event, refund_diem_txn_version=version, refund_reason=reason
+                    )
+        raise ValueError("unrecognized metadata: %r" % event.data.metadata)
+
+    def _refund(self, payee: str, reason: RefundReason, event: jsonrpc.Event) -> None:
+        self.store.create(
+            Transaction,
+            account_id=PENDING_INBOUND_ACCOUNT_ID,
+            status=Transaction.Status.pending,
+            currency=event.data.amount.currency,
+            amount=event.data.amount.amount,
+            payee=payee,
+            refund_diem_txn_version=event.transaction_version,
+            refund_reason=reason,
+        )
 
     def _create_txn(self, account_id: str, event: jsonrpc.Event, **kwargs: Any) -> None:
         self.store.create(

--- a/src/diem/testing/miniwallet/client.py
+++ b/src/diem/testing/miniwallet/client.py
@@ -124,7 +124,7 @@ class AccountResource:
     def log_events(self) -> None:
         events = self.dump_events()
         if events:
-            self.client.logger.info("account(%s) events: %s", (self.id, events))
+            self.client.logger.info("account(%s) events: %s", self.id, events)
 
     def dump_events(self) -> str:
         try:

--- a/src/diem/testing/suites/test_receive_payment.py
+++ b/src/diem/testing/suites/test_receive_payment.py
@@ -1,9 +1,9 @@
 # Copyright (c) The Diem Core Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from diem.testing.miniwallet import RestClient, AccountResource, Transaction
-from diem import identifier
-from typing import Generator
+from diem.testing.miniwallet import RestClient, AccountResource, Transaction, AppConfig, RefundReason
+from diem import jsonrpc, stdlib, utils, txnmetadata, diem_types
+from typing import Generator, Optional
 import pytest
 
 
@@ -31,29 +31,110 @@ def receiver_account(target_client: RestClient) -> Generator[AccountResource, No
     account.log_events()
 
 
-def test_receive_payment_with_general_metadata_and_unknown_to_subaddress(
-    sender_account: AccountResource, receiver_account: AccountResource, currency: str, hrp: str
+@pytest.mark.parametrize("invalid_metadata", [b"", b"invalid metadata"])
+def test_receive_payment_with_invalid_metadata(
+    sender_account: AccountResource,
+    receiver_account: AccountResource,
+    currency: str,
+    hrp: str,
+    stub_config: AppConfig,
+    diem_client: jsonrpc.Client,
+    invalid_metadata: bytes,
 ) -> None:
-    """When received a payment with unknown subaddress, receiver should refund the payment
-    by using RefundMetadata with reason `invalid subaddress`.
+    """When received a payment with invalid metadata, it is up to the wallet application how to handle it.
+    This test makes sure target wallet application should continue to process valid transactions after
+    received such an on-chain transaction.
 
     Test Plan:
     1. Generate a valid payment URI from receiver account.
-    2. Create an invalid payee account identifier by the valid account address and an invalid subaddress.
-    3. Send a payment to the invalid payee.
-    4. Wait for payment completed.
-    5. Assert receiver account does not receive fund.
-    6. Assert sender account balances will has same balances before send the payment eventually.
+    2. Submit a p2p transaction with invalid metadata, and wait for it is executed.
+    3. Send a valid payment to the payment URI.
+    4. Assert receiver account received the valid payment.
     """
 
     uri = receiver_account.generate_payment_uri()
     receiver_account_address = uri.intent(hrp).account_address
-    invalid_subaddress = identifier.gen_subaddress()
-    invalid_payee = identifier.encode_account(receiver_account_address, invalid_subaddress, hrp)
-    payment = sender_account.send_payment(currency=currency, amount=amount, payee=invalid_payee)
-    wait_for_payment_transaction_complete(sender_account, payment.id)
+    stub_config.account.submit_and_wait_for_txn(
+        diem_client,
+        stdlib.encode_peer_to_peer_with_metadata_script(
+            currency=utils.currency_code(currency),
+            amount=amount * 2,
+            payee=receiver_account_address,
+            metadata=invalid_metadata,
+            metadata_signature=b"",
+        ),
+    )
     assert receiver_account.balance(currency) == 0
-    sender_account.wait_for_balance(currency, amount)
+
+    pay = sender_account.send_payment(currency=currency, amount=amount, payee=uri.intent(hrp).account_id)
+    wait_for_payment_transaction_complete(sender_account, pay.id)
+    receiver_account.wait_for_balance(currency, amount)
+
+
+def test_receive_payment_with_general_metadata_and_valid_from_and_to_subaddresses(
+    sender_account: AccountResource, receiver_account: AccountResource, currency: str, hrp: str
+) -> None:
+    """
+    Test Plan:
+    1. Generate a valid payment URI from receiver account.
+    2. Send a payment to the payee from the valid payment URI.
+    4. Wait for the transaction executed successfully.
+    5. Assert receiver account received the fund.
+    """
+    uri = receiver_account.generate_payment_uri()
+    pay = sender_account.send_payment(currency=currency, amount=amount, payee=uri.intent(hrp).account_id)
+    wait_for_payment_transaction_complete(sender_account, pay.id)
+    receiver_account.wait_for_balance(currency, amount)
+
+
+@pytest.mark.parametrize(  # pyre-ignore
+    "invalid_to_subaddress", [None, b"", b"bb4a3ba109a3175f", b"subaddress_more_than_8_bytes", b"too_short"]
+)
+def test_receive_payment_with_general_metadata_and_invalid_to_subaddress(
+    sender_account: AccountResource,
+    receiver_account: AccountResource,
+    currency: str,
+    hrp: str,
+    stub_config: AppConfig,
+    diem_client: jsonrpc.Client,
+    invalid_to_subaddress: Optional[bytes],
+) -> None:
+    """When received a payment with general metadata and invalid to subaddress,
+    receiver should refund the payment by using RefundMetadata with reason `invalid subaddress`.
+
+    Test Plan:
+    1. Generate a valid payment URI from the receiver account.
+    2. Create a general metadata with valid from subaddress and invalid to subaddress.
+    3. Send payment transaction from sender to receiver on-chain account.
+    4. Wait for the transaction executed successfully.
+    5. Assert sender account received a payment transaction with refund metadata.
+    6. Assert receiver account does not receive funds.
+    """
+
+    receiver_uri = receiver_account.generate_payment_uri()
+    receiver_account_address: diem_types.AccountAddress = receiver_uri.intent(hrp).account_address
+
+    sender_uri = sender_account.generate_payment_uri()
+    valid_from_subaddress = sender_uri.intent(hrp).subaddress
+    invalid_metadata = txnmetadata.general_metadata(valid_from_subaddress, invalid_to_subaddress)
+    original_payment_txn: jsonrpc.Transaction = stub_config.account.submit_and_wait_for_txn(
+        diem_client,
+        stdlib.encode_peer_to_peer_with_metadata_script(
+            currency=utils.currency_code(currency),
+            amount=amount,
+            payee=receiver_account_address,
+            metadata=invalid_metadata,
+            metadata_signature=b"",
+        ),
+    )
+
+    sender_account.wait_for_event(
+        "created_transaction",
+        status=Transaction.Status.completed,
+        refund_diem_txn_version=original_payment_txn.version,
+        refund_reason=RefundReason.invalid_subaddress,
+    )
+    assert receiver_account.balance(currency) == 0
 
 
 def wait_for_payment_transaction_complete(account: AccountResource, payment_id: str) -> None:

--- a/src/diem/txnmetadata.py
+++ b/src/diem/txnmetadata.py
@@ -64,8 +64,11 @@ def decode_structure(
     if not bytes_or_str:
         return None
     b = bytes_or_str if isinstance(bytes_or_str, bytes) else bytes.fromhex(bytes_or_str)
-    metadata = diem_types.Metadata.bcs_deserialize(b)
-    return metadata.decode_structure()
+    try:
+        metadata = diem_types.Metadata.bcs_deserialize(b)
+        return metadata.decode_structure()
+    except serde_types.DeserializationError:
+        return None
 
 
 def refund_metadata(original_transaction_version: int, reason: diem_types.RefundReason) -> bytes:

--- a/tests/test_txnmetadata.py
+++ b/tests/test_txnmetadata.py
@@ -187,6 +187,7 @@ def test_decode_structure():
     assert txnmetadata.decode_structure(None) is None
     assert txnmetadata.decode_structure("") is None
     assert txnmetadata.decode_structure(b"") is None
+    assert txnmetadata.decode_structure(b"hello world") is None
 
     gm = txnmetadata.decode_structure("010001088f8b82153010a1bd0000")
     assert isinstance(gm, diem_types.GeneralMetadataV0)


### PR DESCRIPTION
Add test cases:
1. receive payment with invalid metadata: blank or unknown bytes metadata
2. receive payment with general metadata
3. receive payment with general metadata and invalid subaddress: including None, empty, too big and unknown subaddresses