### PR TITLE
add receive payment with general metadata and invalid from subaddress

### DIFF
--- a/src/diem/testing/miniwallet/app/app.py
+++ b/src/diem/testing/miniwallet/app/app.py
@@ -142,7 +142,7 @@ class BackgroundTasks(OffChainAPI):
 
     def _send_pending_payments(self) -> None:
         for txn in self.store.find_all(Transaction, status=Transaction.Status.pending):
-            self.logger.info("processing %s" % txn)
+            self.logger.info("processing %s", txn)
             try:
                 if self.offchain.is_my_account_id(str(txn.payee)):
                     self._send_internal_payment_txn(txn)

--- a/src/diem/testing/miniwallet/app/falcon.py
+++ b/src/diem/testing/miniwallet/app/falcon.py
@@ -17,10 +17,10 @@ class LoggerMiddleware:
     logger: logging.Logger
 
     def process_request(self, req, resp):  # pyre-ignore
-        self.logger.info("%s %s" % (req.method, req.relative_uri))
+        self.logger.debug("%s %s", req.method, req.relative_uri)
 
     def process_response(self, req, resp, *args, **kwargs):  # pyre-ignore
-        self.logger.info(resp.status)
+        self.logger.info("%s %s - %s", req.method, req.relative_uri, resp.status)
 
 
 def rest_handler(fn: Any):  # pyre-ignore
@@ -28,7 +28,7 @@ def rest_handler(fn: Any):  # pyre-ignore
         try:
             try:
                 data = json.load(req.stream)
-                self.app.logger.info("request body: %s" % data)
+                self.app.logger.debug("request body: %s", data)
             except Exception:
                 data = {}
             status, body = fn(self, input=JsonInput(data), **kwargs)

--- a/src/diem/testing/miniwallet/app/models.py
+++ b/src/diem/testing/miniwallet/app/models.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field, asdict, fields
 from enum import Enum
 from typing import Optional, List, Dict, Any
 from .... import identifier, offchain, diem_types
+import json
 
 
 @dataclass
@@ -117,6 +118,9 @@ class Transaction(Base):
 
     def balance_amount(self) -> int:
         return -self.amount if self.payee else self.amount
+
+    def __str__(self) -> str:
+        return "Transaction %s" % json.dumps(asdict(self), indent=2)
 
 
 @dataclass

--- a/src/diem/testing/miniwallet/client.py
+++ b/src/diem/testing/miniwallet/client.py
@@ -60,15 +60,15 @@ class RestClient:
 
     def send(self, method: str, path: str, data: Optional[str] = None) -> requests.Response:
         url = "%s/%s" % (self.server_url.rstrip("/"), path.lstrip("/"))
-        self.logger.debug("%s %s: %s" % (method, path, data))
+        self.logger.debug("%s %s: %s", method, path, data)
         resp = self.session.request(
             method=method,
             url=url.lower(),
             data=data,
             headers={"Content-Type": "application/json", "User-Agent": jsonrpc.client.USER_AGENT_HTTP_HEADER},
         )
-        self.logger.debug("response status code: %s" % resp.status_code)
-        self.logger.debug("response body: %s" % resp.text)
+        self.logger.debug("response status code: %s", resp.status_code)
+        self.logger.debug("response body: %s", resp.text)
         resp.raise_for_status()
         return resp
 

--- a/src/diem/testing/miniwallet/client.py
+++ b/src/diem/testing/miniwallet/client.py
@@ -60,15 +60,15 @@ class RestClient:
 
     def send(self, method: str, path: str, data: Optional[str] = None) -> requests.Response:
         url = "%s/%s" % (self.server_url.rstrip("/"), path.lstrip("/"))
-        self.logger.info("%s %s: %s" % (method, path, data))
+        self.logger.debug("%s %s: %s" % (method, path, data))
         resp = self.session.request(
             method=method,
             url=url.lower(),
             data=data,
             headers={"Content-Type": "application/json", "User-Agent": jsonrpc.client.USER_AGENT_HTTP_HEADER},
         )
-        self.logger.info("response status code: %s" % resp.status_code)
-        self.logger.info("response body: %s" % resp.text)
+        self.logger.debug("response status code: %s" % resp.status_code)
+        self.logger.debug("response body: %s" % resp.text)
         resp.raise_for_status()
         return resp
 

--- a/src/diem/testing/miniwallet/config.py
+++ b/src/diem/testing/miniwallet/config.py
@@ -42,18 +42,18 @@ class AppConfig:
         return self.server_conf.base_url
 
     def create_client(self) -> RestClient:
-        self.logger.info(f"Creating client pointing to {self.server_url}")
+        self.logger.info("Creating client pointing to %s", self.server_url)
         return RestClient(server_url=self.server_url, name="%s-client" % self.name).with_retry()
 
     def setup_account(self, client: jsonrpc.Client) -> None:
         acc = client.get_account(self.account.account_address)
         if not acc or self.need_funds(acc):
-            self.logger.info("faucet mint %s" % self.account.account_address.to_hex())
+            self.logger.info("faucet mint %s", self.account.account_address.to_hex())
             faucet = testnet.Faucet(client)
             faucet.mint(self.account.auth_key.hex(), self.initial_amount, self.initial_currency)
         if not acc or self.need_rotate(acc):
-            self.logger.info("rotate dual attestation info for %s" % self.account.account_address.to_hex())
-            self.logger.info("set base url to: %s" % self.server_url)
+            self.logger.info("rotate dual attestation info for %s", self.account.account_address.to_hex())
+            self.logger.info("set base url to: %s", self.server_url)
             self.account.rotate_dual_attestation_info(client, self.server_url)
 
     def need_funds(self, account: jsonrpc.Account) -> bool:
@@ -75,7 +75,7 @@ class AppConfig:
         api: falcon.API = falcon_api(App(self.account, client, self.name, self.logger), self.enable_debug_api)
 
         def serve() -> None:
-            self.logger.info(f"serving on {self.server_conf.host}:{self.server_conf.port} at {self.server_url}")
+            self.logger.info("serving on %s:%s at %s", self.server_conf.host, self.server_conf.port, self.server_url)
             waitress.serve(
                 api,
                 host=self.server_conf.host,

--- a/src/diem/testing/suites/test_miniwallet_api.py
+++ b/src/diem/testing/suites/test_miniwallet_api.py
@@ -39,28 +39,6 @@ def test_send_payment_and_events(clients: Clients, hrp: str, currency: str) -> N
     assert sorted(list(json.loads(new_events[4].data).keys())) == ["diem_transaction_version", "id", "status"]
 
 
-def test_receive_payment_and_events(clients: Clients, currency: str, hrp: str) -> None:
-    receiver = clients.stub.create_account()
-    payment_uri = receiver.generate_payment_uri()
-
-    index = len(receiver.events())
-    amount = 1234
-    sender = clients.target.create_account({currency: amount})
-    payment = sender.send_payment(currency, amount, payment_uri.intent(hrp).account_id)
-
-    receiver.wait_for_balance(currency, amount)
-    sender.wait_for_balance(currency, 0)
-
-    new_events = [e for e in receiver.events(index) if e.type != "info"]
-    assert len(new_events) == 1
-    assert new_events[0].type == "created_transaction"
-    txn = Transaction(**json.loads(new_events[0].data))
-    assert txn.id
-    assert txn.currency == payment.currency
-    assert txn.amount == payment.amount
-    assert txn.diem_transaction_version
-
-
 def test_receive_multiple_payments(clients: Clients, hrp: str, currency: str) -> None:
     receiver = clients.stub.create_account()
     payment_uri = receiver.generate_payment_uri()

--- a/src/diem/txnmetadata.py
+++ b/src/diem/txnmetadata.py
@@ -125,12 +125,7 @@ def general_metadata(
 
     Give from_subaddress None for the case transferring from non-custodial to custodial account.
     Give to_subaddress None for the case transferring from custodial to non-custodial account.
-
-    Returns empty bytes array if from_subaddress and to_subaddress both are None.
     """
-
-    if from_subaddress is None and to_subaddress is None:
-        return b""
 
     metadata = diem_types.Metadata__GeneralMetadata(
         value=diem_types.GeneralMetadata__GeneralMetadataVersion0(

--- a/tests/test_txnmetadata.py
+++ b/tests/test_txnmetadata.py
@@ -18,7 +18,7 @@ def test_travel_rule_metadata():
 
 def test_new_general_metadata_for_nones():
     ret = txnmetadata.general_metadata(None, None)
-    assert ret == b""
+    assert ret.hex() == "0100000000"
 
 
 def test_new_general_metadata_to_sub_address():


### PR DESCRIPTION
1. added log for processing receive payment events
2. changed to log when submitted transaction failed instead of creating event.
3. changed miniwallet client request & response log level to debug, most of them are duplicated with server side log.
4. added tests:  test_receive_payment_with_general_metadata_and_invalid_from_subaddress and test_receive_payment_with_general_metadata_and_invalid_subaddresses
5. changed txnmetadata.general_metadata to return general metadata bytes instead of blank bytes, which is confusing.