### PR TITLE
add receive payment with travel rule metadata test cases

### DIFF
--- a/src/diem/testing/suites/test_receive_payment.py
+++ b/src/diem/testing/suites/test_receive_payment.py
@@ -12,9 +12,9 @@ amount: int = 123
 
 @pytest.fixture
 def sender_account(
-    stub_client: RestClient, currency: str, pending_income_account: AccountResource
+    stub_client: RestClient, currency: str, pending_income_account: AccountResource, travel_rule_threshold: int
 ) -> Generator[AccountResource, None, None]:
-    account = stub_client.create_account(balances={currency: amount})
+    account = stub_client.create_account(balances={currency: travel_rule_threshold})
     yield account
     account.log_events()
     # MiniWallet stub saves the payment without account information (subaddress / reference id)
@@ -31,7 +31,18 @@ def receiver_account(target_client: RestClient) -> Generator[AccountResource, No
     account.log_events()
 
 
-@pytest.mark.parametrize("invalid_metadata", [b"", b"invalid metadata"])
+@pytest.mark.parametrize(
+    "invalid_metadata",
+    [
+        b"",
+        b"invalid metadata",
+        b"9900000000",  # unknown metadata variant
+        b"0109000000",  # invalid general metadata version
+        b"0209",  # invalid travel rule metadata version
+        b"0409",  # invalid refund metadata version
+        b"0509",  # invalid coin trade metadata version
+    ],
+)
 def test_receive_payment_with_invalid_metadata(
     sender_account: AccountResource,
     receiver_account: AccountResource,
@@ -238,6 +249,90 @@ def test_receive_payment_with_general_metadata_and_invalid_subaddresses(
         status=Transaction.Status.completed,
         refund_diem_txn_version=original_payment_txn.version,
         refund_reason=RefundReason.invalid_subaddress,
+    )
+    assert receiver_account.balance(currency) == 0
+
+
+def test_receive_payment_with_travel_rule_metadata_and_valid_reference_id(
+    sender_account: AccountResource,
+    receiver_account: AccountResource,
+    currency: str,
+    hrp: str,
+    travel_rule_threshold: int,
+) -> None:
+    """
+    Test Plan:
+
+    1. Generate a valid payment URI from receiver account.
+    2. Send a payment meeting travel rule threshold to the payee from the valid payment URI.
+    3. Wait for the transaction executed successfully.
+    4. Assert receiver account received the fund.
+
+    """
+
+    uri = receiver_account.generate_payment_uri()
+    pay = sender_account.send_payment(currency, travel_rule_threshold, payee=uri.intent(hrp).account_id)
+    wait_for_payment_transaction_complete(sender_account, pay.id)
+    receiver_account.wait_for_balance(currency, travel_rule_threshold)
+
+
+@pytest.mark.parametrize(  # pyre-ignore
+    "invalid_ref_id", [None, "", "ref_id_is_not_uuid", "4185027f-0574-6f55-2668-3a38fdb5de98"]
+)
+def test_receive_payment_with_travel_rule_metadata_and_invalid_reference_id(
+    sender_account: AccountResource,
+    receiver_account: AccountResource,
+    currency: str,
+    hrp: str,
+    stub_config: AppConfig,
+    diem_client: jsonrpc.Client,
+    pending_income_account: AccountResource,
+    invalid_ref_id: Optional[str],
+) -> None:
+    """
+    There is no way to create travel rule metadata with invalid reference id when the payment
+    amount meets travel rule threshold, because the metadata signature is verified by transaction
+    script.
+    Also, if metadata signature is provided, transaction script will also verify it regardless
+    whether the amount meets travel rule threshold, thus no need to test invalid metadata
+    signature case.
+
+    This test bypasses the transaction script validation by sending payment amount under the
+    travel rule threshold without metadata signature, and receiver should handle it properly and refund.
+
+    Test Plan:
+
+    1. Generate a valid payment URI from receiver account.
+    2. Submit payment under travel rule threshold transaction from sender to receiver on-chain account.
+    3. Wait for the transaction executed successfully.
+    4. Assert the payment is refund eventually.
+
+    Note: the refund payment will be received by pending income account of the MiniWallet Stub, because
+    no account owns the original invalid payment transaction which is sent by test.
+
+    """
+
+    receiver_uri = receiver_account.generate_payment_uri()
+    receiver_account_address: diem_types.AccountAddress = receiver_uri.intent(hrp).account_address
+
+    sender_uri = sender_account.generate_payment_uri()
+    sender_address = sender_uri.intent(hrp).account_address
+    metadata, _ = txnmetadata.travel_rule(invalid_ref_id, sender_address, amount)  # pyre-ignore
+    original_payment_txn: jsonrpc.Transaction = stub_config.account.submit_and_wait_for_txn(
+        diem_client,
+        stdlib.encode_peer_to_peer_with_metadata_script(
+            currency=utils.currency_code(currency),
+            amount=amount,
+            payee=receiver_account_address,
+            metadata=metadata,
+            metadata_signature=b"",
+        ),
+    )
+
+    pending_income_account.wait_for_event(
+        "created_transaction",
+        status=Transaction.Status.completed,
+        refund_diem_txn_version=original_payment_txn.version,
     )
     assert receiver_account.balance(currency) == 0
 


### PR DESCRIPTION
1. log error with http response code and body when miniwallet client received response code > 300, this highlights the error response content.
2. changed some `logger.error` to `logger.exception`, because `logger.exception` includes error and stacktrace by default.
3. extract out `_find_refund_account_id` function, because `_save_payment_txn` method is too complex (lint complained)
4. extracted out a `find_event` func from `wait_for_event` function in miniwallet RestClient class, was used in test, but later removed from test, I think it's good refactoring, so kept `find_event` method.
5. technically RefundMetadata should only be used for refunding GeneralMetadata invalid subaddress case, for all other cases (like invalid travel rule metadata), we all refund to pending income account, because there is no way to find back account id, as the data is invalid and setup by test only.