### PR TITLE
[PB] Include pyi stub files in pip package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,5 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 recursive-include src *.py
+recursive-include src *.pyi
 recursive-include src *.yaml
 recursive-include src *.html

--- a/src/diem/__VERSION__.py
+++ b/src/diem/__VERSION__.py
@@ -1,4 +1,4 @@
 # Copyright (c) The Diem Core Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-VERSION = "1.2.11"
+VERSION = "1.2.12"


### PR DESCRIPTION
currently our pip packages are missing stub files, which means that the protobuf we ship is completely untyped, and rather incomprehensible