### PR TITLE
add options to dmw commands for supporting host MiniWallet.

### DIFF
--- a/src/diem/local_account.py
+++ b/src/diem/local_account.py
@@ -15,7 +15,7 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey,
 from typing import Dict, Optional, Tuple, Union
 from dataclasses import dataclass, field
 from copy import copy
-import time
+import time, json
 
 
 @dataclass
@@ -142,3 +142,10 @@ class LocalAccount:
         d["private_key"] = utils.private_key_bytes(self.private_key).hex()
         d["compliance_key"] = utils.private_key_bytes(self.compliance_key).hex()
         return d
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), indent=2)
+
+    def write_to_file(self, path: str) -> None:
+        with open(path, "w") as f:
+            f.write(self.to_json())

--- a/src/diem/testing/cli/click.py
+++ b/src/diem/testing/cli/click.py
@@ -64,6 +64,7 @@ def start_server(
     show_default=False,
 )
 @click.option("--test-debug-api", "-d", default=False, help="Run tests for debug APIs.", type=bool)
+@click.option("--logfile", "-l", default=None, help="Log to a file instead of printing into console.")
 @click.option("--verbose", "-v", default=False, help="Enable verbose log output.", type=bool, is_flag=True)
 def test(
     target: str,
@@ -74,6 +75,7 @@ def test(
     faucet: str,
     pytest_args: str,
     test_debug_api: bool,
+    logfile: str,
     verbose: bool,
 ) -> None:
     configure_testnet(jsonrpc, faucet)
@@ -99,6 +101,8 @@ def test(
         args.append("--log-level=INFO")
         args.append("-s")
         args.append("-v")
+    if logfile:
+        args.append("--log-file=%s" % logfile)
 
     code = pytest.main(args)
     sys.stdout.flush()

--- a/src/diem/testing/miniwallet/config.py
+++ b/src/diem/testing/miniwallet/config.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field, asdict
 from typing import Dict, Any
 from .client import RestClient
 from .app import App, falcon_api
-from ... import offchain, testnet, jsonrpc, LocalAccount
+from ... import offchain, testnet, jsonrpc, utils, LocalAccount
 import waitress, threading, logging, falcon, json
 
 
@@ -90,7 +90,9 @@ class AppConfig:
 
     def start(self, client: jsonrpc.Client) -> threading.Thread:
         self.setup_account(client)
-        return self.serve(client)
+        t = self.serve(client)
+        utils.wait_for_port(self.server_conf.port)
+        return t
 
     def __str__(self) -> str:
         return json.dumps(asdict(self), indent=2)

--- a/src/diem/testing/miniwallet/config.py
+++ b/src/diem/testing/miniwallet/config.py
@@ -91,7 +91,7 @@ class AppConfig:
     def start(self, client: jsonrpc.Client) -> threading.Thread:
         self.setup_account(client)
         t = self.serve(client)
-        utils.wait_for_port(self.server_conf.port)
+        utils.wait_for_port(self.server_conf.port, host=self.server_conf.host)
         return t
 
     def __str__(self) -> str:

--- a/src/diem/testing/suites/conftest.py
+++ b/src/diem/testing/suites/conftest.py
@@ -11,8 +11,9 @@ from .envs import (
     is_self_check,
     should_test_debug_api,
     dmw_stub_server,
+    dmw_stub_diem_account_config,
 )
-import pytest
+import pytest, json
 
 
 @pytest.fixture(scope="package")
@@ -35,7 +36,12 @@ def diem_client() -> jsonrpc.Client:
 
 @pytest.fixture(scope="package")
 def stub_config() -> AppConfig:
-    return AppConfig(name="stub-wallet", enable_debug_api=True, server_conf=ServerConfig(**dmw_stub_server()))
+    conf = AppConfig(name="stub-wallet", enable_debug_api=True, server_conf=ServerConfig(**dmw_stub_server()))
+    account_conf = dmw_stub_diem_account_config()
+    if account_conf:
+        print("loads stub account config: %s" % account_conf)
+        conf.account_config = json.loads(account_conf)
+    return conf
 
 
 @pytest.fixture(scope="package")
@@ -55,8 +61,8 @@ def clients(stub_client: RestClient, target_client: RestClient, diem_client: jso
 
 
 @pytest.fixture
-def hrp() -> str:
-    return testnet.HRP
+def hrp(stub_config: AppConfig) -> str:
+    return stub_config.account.hrp
 
 
 @pytest.fixture

--- a/src/diem/testing/suites/envs.py
+++ b/src/diem/testing/suites/envs.py
@@ -12,6 +12,11 @@ SELF_CHECK: str = "DMW_SELF_CHECK"
 DMW_STUB_BIND_HOST: str = "DMW_STUB_BIND_HOST"
 DMW_STUB_BIND_PORT: str = "DMW_STUB_BIND_PORT"
 DMW_STUB_DIEM_ACCOUNT_BASE_URL: str = "DMW_STUB_DIEM_ACCOUNT_BASE_URL"
+DMW_STUB_DIEM_ACCOUNT_CONFIG: str = "DMW_STUB_DIEM_ACCOUNT_CONFIG"
+
+
+def dmw_stub_diem_account_config() -> Optional[str]:
+    return getenv(DMW_STUB_DIEM_ACCOUNT_CONFIG)
 
 
 def dmw_stub_diem_account_base_url() -> Optional[str]:

--- a/tests/test_testing_cli.py
+++ b/tests/test_testing_cli.py
@@ -54,6 +54,7 @@ def test_load_diem_account_config_file(runner: CliRunner) -> None:
 
 
 def start_test(runner: CliRunner, conf: ServerConfig, options: List[str] = []) -> Result:
+    stub_conf = ServerConfig()
     return runner.invoke(
         click.test,
         [
@@ -65,6 +66,12 @@ def start_test(runner: CliRunner, conf: ServerConfig, options: List[str] = []) -
             testnet.FAUCET_URL,
             "--pytest-args",
             "-k test_receive_payment_with_general_metadata_and_valid_from_and_to_subaddresses",
+            "--stub-bind-host",
+            "0.0.0.0",
+            "--stub-bind-port",
+            stub_conf.port,
+            "--stub-diem-account-base-url",
+            stub_conf.base_url,
         ]
         + options,
     )

--- a/tests/test_testing_cli.py
+++ b/tests/test_testing_cli.py
@@ -1,0 +1,92 @@
+# Copyright (c) The Diem Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from click.testing import CliRunner, Result
+from diem.testing.cli import click
+from diem.testing.suites import envs
+from diem.testing.miniwallet import ServerConfig
+from diem import identifier, testnet, utils, LocalAccount
+from typing import List
+import json, threading, pytest
+
+
+@pytest.fixture(autouse=True)
+def disable_self_check(monkeypatch) -> None:
+    monkeypatch.delenv(envs.SELF_CHECK)
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def test_gen_diem_account_config(runner: CliRunner) -> None:
+    result = runner.invoke(click.gen_diem_account_config, [])
+
+    assert result.exit_code == 0
+
+    account = LocalAccount.from_dict(json.loads(result.output))
+    assert account.private_key
+    assert account.compliance_key
+    default = LocalAccount()
+    default.private_key = account.private_key
+    default.compliance_key = account.compliance_key
+    assert default == account
+
+
+def test_start_server_and_run_one_test(runner: CliRunner) -> None:
+    conf = start_target_server(runner)
+    result = start_test(runner, conf)
+    assert result.exit_code == 0, result.output
+
+
+def test_load_diem_account_config_file(runner: CliRunner) -> None:
+    app_config_file = "app.json"
+    stub_config_file = "stub.json"
+    with runner.isolated_filesystem():
+        LocalAccount(hrp=identifier.DM).write_to_file(app_config_file)
+        LocalAccount(hrp=identifier.DM).write_to_file(stub_config_file)
+
+        conf = start_target_server(runner, ["-i", app_config_file])
+        result = start_test(runner, conf, ["-i", stub_config_file])
+
+        assert result.exit_code == 0, result.output
+
+
+def start_test(runner: CliRunner, conf: ServerConfig, options: List[str] = []) -> Result:
+    return runner.invoke(
+        click.test,
+        [
+            "--target",
+            conf.base_url,
+            "--jsonrpc",
+            testnet.JSON_RPC_URL,
+            "--faucet",
+            testnet.FAUCET_URL,
+            "--pytest-args",
+            "-k test_receive_payment_with_general_metadata_and_valid_from_and_to_subaddresses",
+        ]
+        + options,
+    )
+
+
+def start_target_server(runner: CliRunner, options: List[str] = []) -> ServerConfig:
+    conf = ServerConfig()
+
+    def start_server():
+        runner.invoke(
+            click.start_server,
+            [
+                "--jsonrpc",
+                testnet.JSON_RPC_URL,
+                "--faucet",
+                testnet.FAUCET_URL,
+                "--port",
+                conf.port,
+            ]
+            + options,
+        )
+
+    threading.Thread(target=start_server, daemon=True).start()
+    utils.wait_for_port(conf.port)
+    return conf


### PR DESCRIPTION
1. added a logfile option to dmw test command
2. added option to `dmw test` and `dmw start-server` commands for importing diem account configuration
3. added a new command `dmw gen-diem-account-config` for generating simple diem account config file as template for creating the config for `dmw test` or `dmw start-server` 