### PR TITLE
off-chain payment command abort when soft_match

### DIFF
--- a/src/diem/offchain/payment_state.py
+++ b/src/diem/offchain/payment_state.py
@@ -48,7 +48,6 @@ S_ABORT: State[PaymentObject] = State(
     id="S_ABORT",
     require=require(
         status("sender", Status.abort),
-        status("receiver", Status.ready_for_settlement),
     ),
 )
 S_SOFT: State[PaymentObject] = State(
@@ -78,7 +77,6 @@ READY: State[PaymentObject] = State(
 R_ABORT: State[PaymentObject] = State(
     id="R_ABORT",
     require=require(
-        status("sender", Status.needs_kyc_data),
         status("receiver", Status.abort),
     ),
 )
@@ -120,9 +118,11 @@ MACHINE: Machine[PaymentObject] = build_machine(
         new_transition(R_SEND, S_ABORT),
         new_transition(R_SEND, S_SOFT),
         new_transition(R_SOFT, S_SOFT_SEND),
+        new_transition(R_SOFT, S_ABORT),
         new_transition(S_SOFT_SEND, R_ABORT),
         new_transition(S_SOFT_SEND, R_SEND),
         new_transition(S_SOFT, R_SOFT_SEND),
+        new_transition(S_SOFT, R_ABORT),
         new_transition(R_SOFT_SEND, S_ABORT),
         new_transition(R_SOFT_SEND, READY),
     ]

--- a/src/diem/testing/miniwallet/app/app.py
+++ b/src/diem/testing/miniwallet/app/app.py
@@ -239,6 +239,9 @@ class BackgroundTasks(OffChainAPI):
         return self._ready_for_settlement(account_id, cmd)
 
     def _offchain_action_clear_soft_match(self, account_id: str, cmd: offchain.PaymentCommand) -> offchain.Command:
+        account = self.store.find(Account, id=account_id)
+        if account.reject_additional_kyc_data_request:
+            return self._new_reject_kyc_data(cmd, "no need additional KYC data")
         return cmd.new_command(additional_kyc_data="{%r: %r}" % ("account_id", account_id))
 
     def _offchain_action_review_kyc_data(self, account_id: str, cmd: offchain.PaymentCommand) -> offchain.Command:
@@ -265,6 +268,9 @@ class App(BackgroundTasks):
         account = self.store.create(
             Account,
             kyc_data=data.get_nullable("kyc_data", str, self._validate_kyc_data),
+            # reject_additional_kyc_data_request is belongs to mini-wallet stub API, used for
+            # setting up mini-wallet stub to reject additional_kyc_data request.
+            reject_additional_kyc_data_request=data.get_nullable("reject_additional_kyc_data_request", bool),
         )
         balances = data.get_nullable("balances", dict)
         if balances:

--- a/src/diem/testing/miniwallet/app/models.py
+++ b/src/diem/testing/miniwallet/app/models.py
@@ -16,6 +16,7 @@ class Base:
 @dataclass
 class Account(Base):
     kyc_data: Optional[str] = field(default=None)
+    reject_additional_kyc_data_request: Optional[bool] = field(default=False)
 
     def kyc_data_object(self) -> offchain.KycDataObject:
         if self.kyc_data:

--- a/src/diem/testing/miniwallet/client.py
+++ b/src/diem/testing/miniwallet/client.py
@@ -26,9 +26,17 @@ class RestClient:
         return self
 
     def create_account(
-        self, balances: Optional[Dict[str, int]] = None, kyc_data: Optional[str] = None
+        self,
+        balances: Optional[Dict[str, int]] = None,
+        kyc_data: Optional[str] = None,
+        reject_additional_kyc_data_request: Optional[bool] = None,
     ) -> "AccountResource":
-        account = self.create("/accounts", kyc_data=kyc_data, balances=balances)
+        kwargs = {
+            "balances": balances,
+            "kyc_data": kyc_data,
+            "reject_additional_kyc_data_request": reject_additional_kyc_data_request,
+        }
+        account = self.create("/accounts", **{k: v for k, v in kwargs.items() if v})
         return AccountResource(client=self, id=account["id"], kyc_data=account.get("kyc_data", None))
 
     def new_soft_match_kyc_data(self) -> str:


### PR DESCRIPTION
* added special Account property for setting up mini-wallet stub app to always abort the PaymentCommand when KYC is soft_matched. We don't add this property to mini-wallet API specification, because a wallet application does not need it for any test cases.
* integration test is added to validate the change