### PR TITLE
fix offchain module missing response cid when payment command validation failed.

### DIFF
--- a/examples/tests/test_offchain_error_cases.py
+++ b/examples/tests/test_offchain_error_cases.py
@@ -295,6 +295,8 @@ def test_travel_rule_limit_validation(sender_app, receiver_app):
     request = minimum_required_fields_request_sample(sender_app, receiver_app, amount=10)
 
     resp = send_request(request, sender_app, receiver_app, "failure")
+    assert resp.cid
+    assert resp.cid == request["cid"]
     assert_response_command_error(resp, "no_kyc_needed", "command.payment.action.amount")
 
 

--- a/examples/vasp/wallet.py
+++ b/examples/vasp/wallet.py
@@ -143,8 +143,11 @@ class WalletApp:
                     offchain.ErrorCode.missing_http_header, "missing %s" % offchain.X_REQUEST_ID
                 )
 
-            inbound_command = self.offchain_client.process_inbound_request(request_sender_address, request_bytes)
-            cid = inbound_command.id()
+            request = self.offchain_client.deserialize_inbound_request(request_sender_address, request_bytes)
+            cid = request.cid
+            inbound_command = self.offchain_client.process_inbound_payment_command_request(
+                request_sender_address, request
+            )
             self.save_command(inbound_command)
             resp = offchain.reply_request(cid)
             code = 200

--- a/src/diem/__VERSION__.py
+++ b/src/diem/__VERSION__.py
@@ -1,4 +1,4 @@
 # Copyright (c) The Diem Core Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-VERSION = "1.2.11"
+VERSION = "1.2.12"

--- a/tests/test_offchain_client.py
+++ b/tests/test_offchain_client.py
@@ -13,8 +13,8 @@ def test_send_and_deserialize_request(factory):
     receiver_client = factory.create_offchain_client(receiver, client)
 
     def process_inbound_request(x_request_id: str, jws_key_address: str, content: bytes):
-        command = receiver_client.process_inbound_request(jws_key_address, content)
-        resp = offchain.reply_request(command.id())
+        request = receiver_client.deserialize_inbound_request(jws_key_address, content)
+        resp = offchain.reply_request(request.cid)
         return (200, offchain.jws.serialize(resp, receiver.compliance_key.sign))
 
     offchain.http_server.start_local(receiver_port, process_inbound_request)


### PR DESCRIPTION
1. split deserializing request object and payment command validation logic into 2 separated util functions
2. update example wallet and mini-wallet to call separated util functions, and handle the response cid properly.
3. added deprecated warning to offchain client process_inbound_request function, should be removed later.