### PR TITLE
move local_account module into testing package

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,5 +100,5 @@ Sub-modules:
 - `identifier`: Diem Account Identifier and Diem Intent Identifier. [DIP-5](https://dip.diem.com/dip-5/)
 - `txnmetadata`: utils for creating peer to peer transaction metadata. [DIP-4](https://dip.diem.com/dip-4/)
 - `testnet`: Testnet utility, minting coins, create Testnet client, chain id, Testnet JSON-RPC URL.
-- `LocalAccount` | `local_account`: utility for managing local account keys, generate random local account.
+- `testing`: Testing utility, MiniWallet application, MiniWallet test suites, `LocalAccount` for managing local account keys and generating random local account.
 - `chain_ids`: list of static chain ids

--- a/examples/create_child_vasp.py
+++ b/examples/create_child_vasp.py
@@ -9,8 +9,8 @@ from diem import (
     stdlib,
     testnet,
     utils,
-    LocalAccount,
 )
+from diem.testing import LocalAccount
 
 
 def test_create_child_vasp():

--- a/examples/tests/test_offchain_error_cases.py
+++ b/examples/tests/test_offchain_error_cases.py
@@ -10,7 +10,8 @@ from diem.offchain import (
     CommandResponseError,
     PaymentActionObject,
 )
-from diem import LocalAccount, testnet
+from diem import testnet
+from diem.testing import LocalAccount
 from ..vasp.wallet import ActionResult
 import dataclasses, requests, json, copy, pytest, uuid
 

--- a/examples/vasp/wallet.py
+++ b/examples/vasp/wallet.py
@@ -11,9 +11,9 @@ from diem import (
     stdlib,
     testnet,
     utils,
-    LocalAccount,
     offchain,
 )
+from diem.testing import LocalAccount
 import logging, threading, typing
 
 logger: logging.Logger = logging.getLogger(__name__)

--- a/src/diem/__init__.py
+++ b/src/diem/__init__.py
@@ -5,4 +5,6 @@
 
 from .utils import InvalidAccountAddressError, InvalidSubAddressError
 from .auth_key import AuthKey
-from .local_account import LocalAccount
+
+# keep this import for backwards compatible
+from .testing import LocalAccount

--- a/src/diem/testing/__init__.py
+++ b/src/diem/testing/__init__.py
@@ -1,2 +1,11 @@
 # Copyright (c) The Diem Core Contributors
 # SPDX-License-Identifier: Apache-2.0
+
+"""This module provides testing utilities:
+
+1. MiniWallet application as counterparty wallet application stub for testing your wallet application.
+2. Payment test suites provide tests running on top of MiniWallet API for testing wallet application payment features.
+3. `LocalAccount` for managing local account keys and generating random local account.
+"""
+
+from .local_account import LocalAccount

--- a/src/diem/testing/cli/click.py
+++ b/src/diem/testing/cli/click.py
@@ -1,7 +1,8 @@
 # Copyright (c) The Diem Core Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from diem import testnet, LocalAccount
+from diem import testnet
+from diem.testing import LocalAccount
 from diem.testing.miniwallet import AppConfig, ServerConfig
 from diem.testing.suites import envs
 from typing import Optional, TextIO

--- a/src/diem/testing/local_account.py
+++ b/src/diem/testing/local_account.py
@@ -7,10 +7,10 @@ LocalAccount provides operations we need for creating auth key, account address 
 raw transaction.
 """
 
-from . import diem_types, jsonrpc, utils, stdlib, identifier
-from .serde_types import uint64
+from .. import diem_types, jsonrpc, utils, stdlib, identifier
+from ..serde_types import uint64
 
-from .auth_key import AuthKey
+from ..auth_key import AuthKey
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey, Ed25519PublicKey
 from typing import Dict, Optional, Tuple, Union
 from dataclasses import dataclass, field

--- a/src/diem/testing/miniwallet/app/app.py
+++ b/src/diem/testing/miniwallet/app/app.py
@@ -9,7 +9,8 @@ from .diem_account import DiemAccount
 from .models import PaymentUri, Subaddress, Account, Transaction, Event, KycSample, Payment, PaymentCommand
 from .event_puller import EventPuller
 from .json_input import JsonInput
-from .... import jsonrpc, offchain, utils, LocalAccount, identifier
+from ... import LocalAccount
+from .... import jsonrpc, offchain, utils, identifier
 from ....offchain import KycDataObject, Status, AbortCode, CommandResponseObject
 import threading, logging, numpy
 

--- a/src/diem/testing/miniwallet/app/diem_account.py
+++ b/src/diem/testing/miniwallet/app/diem_account.py
@@ -4,7 +4,8 @@
 from dataclasses import dataclass
 from typing import Tuple
 from .models import Transaction, RefundReason
-from .... import jsonrpc, identifier, offchain, stdlib, utils, txnmetadata, LocalAccount
+from ... import LocalAccount
+from .... import jsonrpc, identifier, offchain, stdlib, utils, txnmetadata
 
 
 @dataclass

--- a/src/diem/testing/miniwallet/config.py
+++ b/src/diem/testing/miniwallet/config.py
@@ -5,7 +5,8 @@ from dataclasses import dataclass, field, asdict
 from typing import Dict, Any
 from .client import RestClient
 from .app import App, falcon_api
-from ... import offchain, testnet, jsonrpc, utils, LocalAccount
+from .. import LocalAccount
+from ... import offchain, testnet, jsonrpc, utils
 import waitress, threading, logging, falcon, json
 
 

--- a/src/diem/testnet.py
+++ b/src/diem/testnet.py
@@ -5,7 +5,8 @@
 
 ```python
 
-from diem import testnet, LocalAccount
+from diem import testnet
+from diem.testing import LocalAccount
 
 # create client connects to testnet
 client = testnet.create_client()
@@ -23,7 +24,8 @@ account: LocalAccount = faucet.gen_account()
 import requests
 import typing
 
-from . import diem_types, jsonrpc, utils, chain_ids, bcs, stdlib, identifier, LocalAccount
+from . import diem_types, jsonrpc, utils, chain_ids, bcs, stdlib, identifier
+from .testing import LocalAccount
 
 
 JSON_RPC_URL: str = "http://testnet.diem.com/v1"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from diem import testnet, offchain, identifier, LocalAccount
+from diem import testnet, offchain, identifier
+from diem.testing import LocalAccount
 import pytest
 
 

--- a/tests/test_local_account.py
+++ b/tests/test_local_account.py
@@ -1,7 +1,8 @@
 # Copyright (c) The Diem Core Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from diem import identifier, utils, LocalAccount
+from diem import identifier, utils
+from diem.testing import LocalAccount
 
 
 def test_from_private_key_hex():

--- a/tests/test_offchain_jws.py
+++ b/tests/test_offchain_jws.py
@@ -1,7 +1,8 @@
 # Copyright (c) The Diem Core Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from diem import offchain, LocalAccount
+from diem import offchain
+from diem.testing import LocalAccount
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 import cryptography, pytest
 

--- a/tests/test_offchain_types.py
+++ b/tests/test_offchain_types.py
@@ -1,7 +1,8 @@
 # Copyright (c) The Diem Core Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from diem import identifier, offchain, LocalAccount
+from diem import identifier, offchain
+from diem.testing import LocalAccount
 import dataclasses, json, pytest, uuid
 
 

--- a/tests/test_testing_cli.py
+++ b/tests/test_testing_cli.py
@@ -5,7 +5,8 @@ from click.testing import CliRunner, Result
 from diem.testing.cli import click
 from diem.testing.suites import envs
 from diem.testing.miniwallet import ServerConfig
-from diem import identifier, testnet, utils, LocalAccount
+from diem.testing import LocalAccount
+from diem import identifier, testnet, utils
 from typing import List
 import json, threading, pytest
 

--- a/tests/test_testnet.py
+++ b/tests/test_testnet.py
@@ -9,8 +9,8 @@ from diem import (
     testnet,
     utils,
     InvalidAccountAddressError,
-    LocalAccount,
 )
+from diem.testing import LocalAccount
 
 import time
 import pytest


### PR DESCRIPTION
* `LocalAccount` should only be used in test environment, move it into testing package and update codebase to import it from diem.testing package.
* For backwards compatible, we still import LocalAccount in diem package, may remove when we bump up major version of SDK.