### PR TITLE
mini-wallet api change: remove response fields that don't have clear use cases.

### DIFF
--- a/src/diem/__VERSION__.py
+++ b/src/diem/__VERSION__.py
@@ -1,4 +1,4 @@
 # Copyright (c) The Diem Core Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-VERSION = "1.2.12"
+VERSION = "1.3.12"

--- a/src/diem/testing/local_account.py
+++ b/src/diem/testing/local_account.py
@@ -116,6 +116,18 @@ class LocalAccount:
         )
 
     def submit_txn(self, client: jsonrpc.Client, script: diem_types.Script) -> diem_types.SignedTransaction:
+        """submit transaction with the given script
+
+        This function creates transaction with current account sequence number (by json-rpc `get_account`
+        method), and retries on JsonRpcError in case there is another process is submitting transaction
+        at same time, which may cause SEQUENCE_NUMBER_TOO_OLD JsonRpcError.
+        """
+        retry = jsonrpc.Retry(10, 0.1, jsonrpc.JsonRpcError)
+        return retry.execute(lambda: self._submit_txn_without_retry(client, script))
+
+    def _submit_txn_without_retry(
+        self, client: jsonrpc.Client, script: diem_types.Script
+    ) -> diem_types.SignedTransaction:
         txn = self.create_txn(client, script)
         client.submit(txn)
         return txn

--- a/src/diem/testing/miniwallet/app/app.py
+++ b/src/diem/testing/miniwallet/app/app.py
@@ -296,7 +296,7 @@ class App(BackgroundTasks):
                 self._create_transaction(
                     account.id, Transaction.Status.completed, JsonInput({"currency": c, "amount": a})
                 )
-        return account
+        return Account(id=account.id)
 
     def create_account_payment(self, account_id: str, data: JsonInput) -> Payment:
         self.store.find(Account, id=account_id)
@@ -311,7 +311,7 @@ class App(BackgroundTasks):
         sub = self._gen_subaddress(account_id)
         diem_acc_id = self.diem_account.account.account_identifier(sub.subaddress_hex)
         uri = identifier.encode_intent(diem_acc_id, currency, amount)
-        return PaymentUri(id=sub.id, account_id=account_id, currency=currency, amount=amount, payment_uri=uri)
+        return PaymentUri(id=sub.id, account_id=account_id, payment_uri=uri)
 
     def get_account_balances(self, account_id: str) -> Dict[str, int]:
         self.store.find(Account, id=account_id)

--- a/src/diem/testing/miniwallet/app/models.py
+++ b/src/diem/testing/miniwallet/app/models.py
@@ -29,8 +29,6 @@ class Account(Base):
 class PaymentUri(Base):
     account_id: str
     payment_uri: str
-    currency: Optional[str] = field(default=None)
-    amount: Optional[int] = field(default=None)
 
     def intent(self, hrp: str) -> identifier.Intent:
         return identifier.decode_intent(self.payment_uri, hrp)

--- a/src/diem/testing/miniwallet/app/static/openapi.yaml
+++ b/src/diem/testing/miniwallet/app/static/openapi.yaml
@@ -276,8 +276,6 @@ components:
         id:
           type: string
           readOnly: true
-        kyc_data:
-          $ref: '#/components/schemas/KycDataObject'
     CreateAccountRequest:
       type: object
       properties:
@@ -301,8 +299,10 @@ components:
         currency:
           type: string
           enum: ["XUS", "XDX"]
+          writeOnly: true
         amount:
           type: integer
+          writeOnly: true
         payment_uri:
           type: string
           description: >

--- a/src/diem/testing/suites/test_create_test_account.py
+++ b/src/diem/testing/suites/test_create_test_account.py
@@ -9,7 +9,6 @@ import pytest
 def test_create_a_blank_account(target_client: RestClient) -> None:
     account = target_client.create_account()
     assert account.id
-    assert account.kyc_data is None
     assert account.balance("XUS") == 0
     assert account.balance("XDX") == 0
 
@@ -19,7 +18,6 @@ def test_create_a_blank_account(target_client: RestClient) -> None:
 def test_create_an_account_with_initial_deposit_balances(target_client: RestClient, currency: str, amount: int) -> None:
     account = target_client.create_account(kyc_data=None, balances={currency: amount})
     assert account.id
-    assert account.kyc_data is None
     assert account.balance(currency) == amount
 
 
@@ -33,7 +31,6 @@ def test_create_an_account_with_initial_deposit_balances(target_client: RestClie
 def test_create_an_account_with_minimum_valid_kyc_data(target_client: RestClient, kyc_data: str) -> None:
     account = target_client.create_account(kyc_data=kyc_data)
     assert account.id
-    assert account.kyc_data == kyc_data
 
 
 def test_create_an_account_with_valid_kyc_data_and_initial_deposit_balances(
@@ -42,7 +39,6 @@ def test_create_an_account_with_valid_kyc_data_and_initial_deposit_balances(
     minimum_kyc_data = offchain.to_json(offchain.individual_kyc_data())
     account = target_client.create_account(kyc_data=minimum_kyc_data, balances={currency: 123})
     assert account.id
-    assert account.kyc_data == minimum_kyc_data
 
 
 def test_account_id_should_be_unique(target_client: RestClient) -> None:

--- a/src/diem/testing/suites/test_generate_account_payment_uri.py
+++ b/src/diem/testing/suites/test_generate_account_payment_uri.py
@@ -17,8 +17,6 @@ def test_generate_account_payment_uri_without_currency_and_amount(account: Accou
     uri = account.generate_payment_uri()
     assert uri.id
     assert uri.account_id == account.id
-    assert uri.currency is None
-    assert uri.amount is None
     assert uri.payment_uri
 
     intent = identifier.decode_intent(uri.payment_uri, hrp)
@@ -32,8 +30,6 @@ def test_generate_account_payment_uri_with_currency(account: AccountResource, cu
     uri = account.generate_payment_uri(currency=currency)
     assert uri.id
     assert uri.account_id == account.id
-    assert uri.currency == currency
-    assert uri.amount is None
 
     intent = identifier.decode_intent(uri.payment_uri, hrp)
     assert intent.account_address
@@ -47,8 +43,6 @@ def test_generate_account_payment_uri_with_amount(account: AccountResource, hrp:
     uri = account.generate_payment_uri(amount=amount)
     assert uri.id
     assert uri.account_id == account.id
-    assert uri.currency is None
-    assert uri.amount == amount
 
     intent = identifier.decode_intent(uri.payment_uri, hrp)
     assert intent.account_address
@@ -64,8 +58,6 @@ def test_generate_account_payment_uri_with_currency_and_amount(
     uri = account.generate_payment_uri(currency=currency, amount=amount)
     assert uri.id
     assert uri.account_id == account.id
-    assert uri.currency == currency
-    assert uri.amount == amount
 
     intent = identifier.decode_intent(uri.payment_uri, hrp)
     assert intent.account_address

--- a/tests/miniwallet/test_store.py
+++ b/tests/miniwallet/test_store.py
@@ -45,9 +45,11 @@ def test_find_all():
 
 def test_find_all_by_matching_default_none():
     s = store.InMemoryStore()
-    uri = s.create(PaymentUri, account_id="1", payment_uri="payment uri")
-    assert s.find_all(PaymentUri, currency=None, account_id="1") == [uri]
-    assert s.find_all(PaymentUri, currency="XUS") == []
+    cmd = s.create(
+        PaymentCommand, account_id="1", reference_id="2", cid="3", is_sender=True, process_error=None, payment_object={}
+    )
+    assert s.find_all(PaymentCommand, process_error=None, account_id="1") == [cmd]
+    assert s.find_all(PaymentCommand, currency="XUS") == []
 
 
 def test_find_all_by_matching_default_bool_values():


### PR DESCRIPTION
Feedback from Rashmi when implementing Novi mini-wallet proxy, the following fields mostly like won't have meaningful use cases, and we saw similar implementation pattern in DRW proxy as well. 
1. removed kyc_data in create account response: most likely server side just return the data in the request.
2. removed currency and amount in generated payment uri response: most likely server side just return the data in the request.