### PR TITLE
add offchain api protocol error cases for missing/invalid http headers

### DIFF
--- a/src/diem/offchain/__init__.py
+++ b/src/diem/offchain/__init__.py
@@ -38,6 +38,7 @@ from .types import (
     from_json,
     from_dict,
     validate_write_once_fields,
+    UUID_REGEX,
 )
 from .http_header import X_REQUEST_ID, X_REQUEST_SENDER_ADDRESS
 from .action import Action

--- a/src/diem/offchain/types/__init__.py
+++ b/src/diem/offchain/types/__init__.py
@@ -15,6 +15,7 @@ from .command_types import (
     CommandRequestObject,
     CommandResponseStatus,
     FundPullPreApprovalCommandObject,
+    UUID_REGEX,
 )
 from .payment_types import (
     AbortCode,

--- a/src/diem/testing/miniwallet/app/api.py
+++ b/src/diem/testing/miniwallet/app/api.py
@@ -75,6 +75,10 @@ class Endpoints:
         request_sender_address = req.get_header(offchain.X_REQUEST_SENDER_ADDRESS)
         input_data = req.stream.read()
         try:
+            if not offchain.UUID_REGEX.match(request_id):
+                raise offchain.protocol_error(
+                    offchain.ErrorCode.invalid_http_header, "invalid %s" % offchain.X_REQUEST_ID
+                )
             resp_obj = self.app.offchain_api(request_sender_address, input_data)
         except offchain.Error as e:
             self.app.logger.info(input_data)

--- a/src/diem/testing/miniwallet/app/api.py
+++ b/src/diem/testing/miniwallet/app/api.py
@@ -75,6 +75,10 @@ class Endpoints:
         request_sender_address = req.get_header(offchain.X_REQUEST_SENDER_ADDRESS)
         input_data = req.stream.read()
         try:
+            if not request_id:
+                raise offchain.protocol_error(
+                    offchain.ErrorCode.missing_http_header, "missing %s" % offchain.X_REQUEST_ID
+                )
             if not offchain.UUID_REGEX.match(request_id):
                 raise offchain.protocol_error(
                     offchain.ErrorCode.invalid_http_header, "invalid %s" % offchain.X_REQUEST_ID

--- a/src/diem/testing/suites/test_offchain_protocol_error_cases.py
+++ b/src/diem/testing/suites/test_offchain_protocol_error_cases.py
@@ -5,7 +5,7 @@ from diem import identifier, jsonrpc, offchain
 from diem.testing import LocalAccount
 from diem.testing.miniwallet import RestClient, AppConfig
 from typing import Dict, Any, Tuple, Optional
-import json, time, requests, uuid
+import json, time, requests, uuid, pytest
 
 
 def test_invalid_x_request_id(
@@ -24,7 +24,8 @@ def test_invalid_x_request_id(
     2. Send request to the target wallet application offchain API endpoint with X-Request-ID does not
        match UUID format.
     3. Expect response status code is 400
-    4. Expect response `CommandResponseObject` with failure status and error object
+    4. Expect response `CommandResponseObject` with failure status, `protocol_error` error type,
+       and `invalid_http_header` error code.
     """
 
     receiver_address = target_client.create_account().generate_account_identifier(hrp)
@@ -50,24 +51,160 @@ def test_invalid_x_request_id(
     assert_response_error(resp, "invalid_http_header", "protocol_error")
 
 
+def test_missing_x_request_id(
+    stub_config: AppConfig,
+    target_client: RestClient,
+    stub_client: RestClient,
+    diem_client: jsonrpc.Client,
+    currency: str,
+    travel_rule_threshold: int,
+    hrp: str,
+) -> None:
+    """
+    Test Plan:
+
+    1. Create a valid offchain request object.
+    2. Send request to the target wallet application offchain API endpoint without X-Request-ID.
+    3. Expect response status code is 400
+    4. Expect response `CommandResponseObject` with failure status, `protocol_error` error type,
+       and `missing_http_header` error code.
+    """
+
+    receiver_address = target_client.create_account().generate_account_identifier(hrp)
+    sender_address = stub_client.create_account().generate_account_identifier(hrp)
+    request = payment_command_request_sample(
+        sender_address=sender_address,
+        sender_kyc_data=json.loads(target_client.new_kyc_data(sample="minimum")),
+        receiver_address=receiver_address,
+        currency=currency,
+        amount=travel_rule_threshold,
+    )
+    status_code, resp = send_request_json(
+        diem_client,
+        stub_config.account,
+        sender_address,
+        receiver_address,
+        json.dumps(request),
+        hrp,
+        x_request_id=None,
+    )
+    assert status_code == 400
+    assert resp.status == "failure"
+    assert_response_error(resp, "missing_http_header", "protocol_error")
+
+
+@pytest.mark.parametrize(
+    "invalid_sender_address",
+    [
+        "invalid hex-encoded address",
+        "18e97a844979a76b030119db95aaf9d0",
+        "xdm1p7ujcndcl7nudzwt8fglhx6wxn08kgs5tm6mz4us2vfufk",
+    ],
+)
+def test_invalid_x_request_sender_address(
+    stub_config: AppConfig,
+    target_client: RestClient,
+    stub_client: RestClient,
+    diem_client: jsonrpc.Client,
+    currency: str,
+    travel_rule_threshold: int,
+    hrp: str,
+    invalid_sender_address: str,
+) -> None:
+    """
+    Test Plan:
+
+    1. Create a valid offchain request object.
+    2. Send request to the target wallet application offchain API endpoint with invalid X-Request-Sender-Address.
+    3. Expect response status code is 400
+    4. Expect response `CommandResponseObject` with failure status, `protocol_error` error type,
+       and `invalid_http_header` error code.
+    """
+
+    receiver_address = target_client.create_account().generate_account_identifier(hrp)
+    sender_address = stub_client.create_account().generate_account_identifier(hrp)
+    request = payment_command_request_sample(
+        sender_address=sender_address,
+        sender_kyc_data=json.loads(target_client.new_kyc_data(sample="minimum")),
+        receiver_address=receiver_address,
+        currency=currency,
+        amount=travel_rule_threshold,
+    )
+    status_code, resp = send_request_json(
+        diem_client,
+        stub_config.account,
+        invalid_sender_address,
+        receiver_address,
+        json.dumps(request),
+        hrp,
+    )
+    assert status_code == 400
+    assert resp.status == "failure"
+    assert_response_error(resp, "invalid_http_header", "protocol_error")
+
+
+def test_missing_x_request_sender_address(
+    stub_config: AppConfig,
+    target_client: RestClient,
+    stub_client: RestClient,
+    diem_client: jsonrpc.Client,
+    currency: str,
+    travel_rule_threshold: int,
+    hrp: str,
+) -> None:
+    """
+    Test Plan:
+
+    1. Create a valid offchain request object.
+    2. Send request to the target wallet application offchain API endpoint without X-Request-Sender-Address header.
+    3. Expect response status code is 400
+    4. Expect response `CommandResponseObject` with failure status, `protocol_error` error type,
+       and `missing_http_header` error code.
+    """
+
+    receiver_address = target_client.create_account().generate_account_identifier(hrp)
+    sender_address = stub_client.create_account().generate_account_identifier(hrp)
+    request = payment_command_request_sample(
+        sender_address=sender_address,
+        sender_kyc_data=json.loads(target_client.new_kyc_data(sample="minimum")),
+        receiver_address=receiver_address,
+        currency=currency,
+        amount=travel_rule_threshold,
+    )
+    status_code, resp = send_request_json(
+        diem_client,
+        stub_config.account,
+        None,
+        receiver_address,
+        json.dumps(request),
+        hrp,
+    )
+    assert status_code == 400
+    assert resp.status == "failure"
+    assert_response_error(resp, "missing_http_header", "protocol_error")
+
+
 def send_request_json(
     diem_client: jsonrpc.Client,
     sender_account: LocalAccount,
-    sender_address: str,
+    sender_address: Optional[str],
     receiver_address: str,
     request_json: str,
     hrp: str,
-    x_request_id: str = str(uuid.uuid4()),
+    x_request_id: Optional[str] = str(uuid.uuid4()),
 ) -> Tuple[int, offchain.CommandResponseObject]:
+    headers = {}
+    if x_request_id:
+        headers[offchain.http_header.X_REQUEST_ID] = x_request_id
+    if sender_address:
+        headers[offchain.http_header.X_REQUEST_SENDER_ADDRESS] = sender_address
+
     account_address, _ = identifier.decode_account(receiver_address, hrp)
     base_url, public_key = diem_client.get_base_url_and_compliance_key(account_address)
     resp = requests.Session().post(
         f"{base_url.rstrip('/')}/v2/command",
         data=offchain.jws.serialize_string(request_json, sender_account.compliance_key.sign),
-        headers={
-            offchain.http_header.X_REQUEST_ID: x_request_id,
-            offchain.http_header.X_REQUEST_SENDER_ADDRESS: sender_address,
-        },
+        headers=headers,
     )
 
     cmd_resp_obj = offchain.jws.deserialize(resp.content, offchain.CommandResponseObject, public_key.verify)
@@ -87,12 +224,12 @@ def payment_command_request_sample(
 
     return {
         "_ObjectType": "CommandRequestObject",
-        "cid": "c77053c9-9c44-4c84-aaf5-aa142eab23fc",
+        "cid": str(uuid.uuid4()),
         "command_type": "PaymentCommand",
         "command": {
             "_ObjectType": "PaymentCommand",
             "payment": {
-                "reference_id": "18c2006f-f29f-4ec7-b0e1-399505e58aa2",
+                "reference_id": str(uuid.uuid4()),
                 "sender": {
                     "address": sender_address,
                     "status": {"status": "needs_kyc_data"},

--- a/src/diem/testing/suites/test_offchain_protocol_error_cases.py
+++ b/src/diem/testing/suites/test_offchain_protocol_error_cases.py
@@ -1,0 +1,122 @@
+# Copyright (c) The Diem Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from diem import identifier, jsonrpc, offchain
+from diem.testing import LocalAccount
+from diem.testing.miniwallet import RestClient, AppConfig
+from typing import Dict, Any, Tuple, Optional
+import json, time, requests, uuid
+
+
+def test_invalid_x_request_id(
+    stub_config: AppConfig,
+    target_client: RestClient,
+    stub_client: RestClient,
+    diem_client: jsonrpc.Client,
+    currency: str,
+    travel_rule_threshold: int,
+    hrp: str,
+) -> None:
+    """
+    Test Plan:
+
+    1. Create a valid offchain request object.
+    2. Send request to the target wallet application offchain API endpoint with X-Request-ID does not
+       match UUID format.
+    3. Expect response status code is 400
+    4. Expect response `CommandResponseObject` with failure status and error object
+    """
+
+    receiver_address = target_client.create_account().generate_account_identifier(hrp)
+    sender_address = stub_client.create_account().generate_account_identifier(hrp)
+    request = payment_command_request_sample(
+        sender_address=sender_address,
+        sender_kyc_data=json.loads(target_client.new_kyc_data(sample="minimum")),
+        receiver_address=receiver_address,
+        currency=currency,
+        amount=travel_rule_threshold,
+    )
+    status_code, resp = send_request_json(
+        diem_client,
+        stub_config.account,
+        sender_address,
+        receiver_address,
+        json.dumps(request),
+        hrp,
+        x_request_id="invalid uuid",
+    )
+    assert status_code == 400
+    assert resp.status == "failure"
+    assert_response_error(resp, "invalid_http_header", "protocol_error")
+
+
+def send_request_json(
+    diem_client: jsonrpc.Client,
+    sender_account: LocalAccount,
+    sender_address: str,
+    receiver_address: str,
+    request_json: str,
+    hrp: str,
+    x_request_id: str = str(uuid.uuid4()),
+) -> Tuple[int, offchain.CommandResponseObject]:
+    account_address, _ = identifier.decode_account(receiver_address, hrp)
+    base_url, public_key = diem_client.get_base_url_and_compliance_key(account_address)
+    resp = requests.Session().post(
+        f"{base_url.rstrip('/')}/v2/command",
+        data=offchain.jws.serialize_string(request_json, sender_account.compliance_key.sign),
+        headers={
+            offchain.http_header.X_REQUEST_ID: x_request_id,
+            offchain.http_header.X_REQUEST_SENDER_ADDRESS: sender_address,
+        },
+    )
+
+    cmd_resp_obj = offchain.jws.deserialize(resp.content, offchain.CommandResponseObject, public_key.verify)
+
+    return (resp.status_code, cmd_resp_obj)
+
+
+def payment_command_request_sample(
+    sender_address: str, sender_kyc_data: Dict[str, Any], receiver_address: str, currency: str, amount: int
+) -> Dict[str, Any]:
+    """Creates a `PaymentCommand` initial state request JSON object (dictionary).
+
+    Sender address is from the stub wallet application.
+
+    Receiver address is from the target wallet application.
+    """
+
+    return {
+        "_ObjectType": "CommandRequestObject",
+        "cid": "c77053c9-9c44-4c84-aaf5-aa142eab23fc",
+        "command_type": "PaymentCommand",
+        "command": {
+            "_ObjectType": "PaymentCommand",
+            "payment": {
+                "reference_id": "18c2006f-f29f-4ec7-b0e1-399505e58aa2",
+                "sender": {
+                    "address": sender_address,
+                    "status": {"status": "needs_kyc_data"},
+                    "kyc_data": sender_kyc_data,
+                },
+                "receiver": {
+                    "address": receiver_address,
+                    "status": {"status": "none"},
+                },
+                "action": {
+                    "amount": amount,
+                    "currency": currency,
+                    "action": "charge",
+                    "timestamp": int(time.time()),
+                },
+            },
+        },
+    }
+
+
+def assert_response_error(
+    resp: offchain.CommandResponseObject, code: str, err_type: str, field: Optional[str] = None
+) -> None:
+    assert resp.error, resp
+    assert resp.error.type == err_type, resp
+    assert resp.error.code == code, resp
+    assert resp.error.field == field, resp

--- a/src/diem/testing/suites/test_receive_payment.py
+++ b/src/diem/testing/suites/test_receive_payment.py
@@ -282,7 +282,7 @@ def test_receive_payment_with_travel_rule_metadata_and_valid_reference_id(
 
 
 @pytest.mark.parametrize(  # pyre-ignore
-    "invalid_ref_id", [None, "", "ref_id_is_not_uuid", "4185027f-0574-6f55-2668-3a38fdb5de98"]
+    "invalid_ref_id", [None, "", "ref_id_is_not_uuid", "6cd81d79-f041-4f28-867f-e4d54950833e"]
 )
 def test_receive_payment_with_travel_rule_metadata_and_invalid_reference_id(
     sender_account: AccountResource,

--- a/src/diem/testing/suites/test_receive_payment.py
+++ b/src/diem/testing/suites/test_receive_payment.py
@@ -740,11 +740,11 @@ def receive_payment_meets_travel_rule_threshold(
     sender_initial = sender.balance(currency)
     receiver_initial = receiver.balance(currency)
 
-    payment_uri = receiver.generate_payment_uri()
-    send_payment = sender.send_payment(currency, amount, payment_uri.intent(hrp).account_id)
+    payee = receiver.generate_account_identifier(hrp)
+    send_payment = sender.send_payment(currency, amount, payee)
     assert send_payment.currency == currency
     assert send_payment.amount == amount
-    assert send_payment.payee == payment_uri.intent(hrp).account_id
+    assert send_payment.payee == payee
 
     def match_exchange_states() -> None:
         states = []

--- a/src/diem/testing/suites/test_send_payment.py
+++ b/src/diem/testing/suites/test_send_payment.py
@@ -53,8 +53,9 @@ def receiver_account(stub_client: RestClient) -> Generator[AccountResource, None
 
 @pytest.fixture
 def receiver_account_identifier(receiver_account: AccountResource, hrp: str) -> str:
-    payment_uri = receiver_account.generate_payment_uri()
-    return payment_uri.intent(hrp).account_id
+    """Generates a new receiver account identifier"""
+
+    return receiver_account.generate_account_identifier(hrp)
 
 
 @pytest.mark.parametrize("invalid_currency", ["XU", "USD", "xus", "", '"XUS"', "X"])
@@ -240,7 +241,7 @@ def test_send_payment_to_the_other_account_in_the_same_wallet(
 
     sender_initial_balance = sender_account.balance(currency)
     receiver_account = target_client.create_account()
-    receiver_account_identifier = receiver_account.generate_payment_uri().intent(hrp).account_id
+    receiver_account_identifier = receiver_account.generate_account_identifier(hrp)
 
     payment = sender_account.send_payment(currency, amount, payee=receiver_account_identifier)
     assert payment.amount == amount
@@ -584,11 +585,11 @@ def send_payment_meets_travel_rule_threshold(
     sender_initial = sender.balance(currency)
     receiver_initial = receiver.balance(currency)
 
-    payment_uri = receiver.generate_payment_uri()
-    send_payment = sender.send_payment(currency, amount, payment_uri.intent(hrp).account_id)
+    payee = receiver.generate_account_identifier(hrp)
+    send_payment = sender.send_payment(currency, amount, payee)
     assert send_payment.currency == currency
     assert send_payment.amount == amount
-    assert send_payment.payee == payment_uri.intent(hrp).account_id
+    assert send_payment.payee == payee
 
     def match_exchange_states() -> None:
         states = []


### PR DESCRIPTION
1. missing / invalid x-request-id
2. missing / invalid x-request-sender-address
3. added mini-wallet AccountResource#generate_account_identifier for sharing generating account identifier logic across tests
4. added some documents to mini-wallet AccountResource methods. 