### PR TITLE
add off-chain protocol error test cases: invalid x_request_sender_address, jws, and jws signature

### DIFF
--- a/src/diem/offchain/__init__.py
+++ b/src/diem/offchain/__init__.py
@@ -35,6 +35,7 @@ from .types import (
     individual_kyc_data,
     entity_kyc_data,
     to_json,
+    to_dict,
     from_json,
     from_dict,
     validate_write_once_fields,

--- a/src/diem/offchain/types/command_types.py
+++ b/src/diem/offchain/types/command_types.py
@@ -89,10 +89,6 @@ class OffChainErrorType:
     protocol_error = "protocol_error"
 
 
-# Late import to solve circular dependency and be able to list all the command types
-from .payment_types import PaymentCommandObject
-
-
 @dataclass(frozen=True)
 class FundPullPreApprovalCommandObject:
     _ObjectType: str = datafield(metadata={"valid-values": [CommandType.FundPullPreApprovalCommand]})
@@ -103,10 +99,8 @@ class CommandRequestObject:
     # A unique identifier for the Command.
     cid: str = datafield(metadata={"valid-values": UUID_REGEX})
     # A string representing the type of Command contained in the request.
-    command_type: str = datafield(
-        metadata={"valid-values": [CommandType.PaymentCommand, CommandType.FundPullPreApprovalCommand]}
-    )
-    command: typing.Union[PaymentCommandObject, FundPullPreApprovalCommandObject]
+    command_type: str
+    command: dict  # pyre-ignore
     _ObjectType: str = datafield(default="CommandRequestObject", metadata={"valid-values": ["CommandRequestObject"]})
 
 

--- a/src/diem/testing/local_account.py
+++ b/src/diem/testing/local_account.py
@@ -136,12 +136,14 @@ class LocalAccount:
         txn = self.submit_txn(client, script)
         return client.wait_for_transaction(txn, timeout_secs=self.txn_expire_duration_secs)
 
-    def rotate_dual_attestation_info(self, client: jsonrpc.Client, base_url: str) -> jsonrpc.Transaction:
+    def rotate_dual_attestation_info(
+        self, client: jsonrpc.Client, base_url: str, compliance_key: Optional[bytes] = None
+    ) -> jsonrpc.Transaction:
+        if not compliance_key:
+            compliance_key = self.compliance_public_key_bytes
         return self.submit_and_wait_for_txn(
             client,
-            stdlib.encode_rotate_dual_attestation_info_script(
-                new_url=base_url.encode("utf-8"), new_key=self.compliance_public_key_bytes
-            ),
+            stdlib.encode_rotate_dual_attestation_info_script(new_url=base_url.encode("utf-8"), new_key=compliance_key),
         )
 
     def to_dict(self) -> Dict[str, str]:


### PR DESCRIPTION
1. Change deserializing CommandRequestObject JSON into 2 steps: first deserialize CommandRequestObject without command field, and raise all deserialization error as protocol_error, then deserialize Command object based on command_type and raise any deserialization error as command_error.
2. add test_x_request_sender_is_valid_but_no_compliance_key
3. add test_invalid_jws_message_body_that_misses_parts
4. test_invalid_jws_message_signature