### PR TITLE
relax test assersion: do not assume generated account identifier has subaddress

### DIFF
--- a/src/diem/testing/suites/test_generate_account_payment_uri.py
+++ b/src/diem/testing/suites/test_generate_account_payment_uri.py
@@ -3,7 +3,7 @@
 
 
 from diem.testing.miniwallet import RestClient, AccountResource
-from diem import identifier, utils
+from diem import identifier
 from typing import Union
 import pytest, requests
 
@@ -21,7 +21,6 @@ def test_generate_account_payment_uri_without_currency_and_amount(account: Accou
 
     intent = identifier.decode_intent(uri.payment_uri, hrp)
     assert intent.account_address
-    assert intent.subaddress
     assert intent.currency_code is None
     assert intent.amount is None
 
@@ -33,7 +32,6 @@ def test_generate_account_payment_uri_with_currency(account: AccountResource, cu
 
     intent = identifier.decode_intent(uri.payment_uri, hrp)
     assert intent.account_address
-    assert intent.subaddress
     assert intent.currency_code == currency
     assert intent.amount is None
 
@@ -46,7 +44,6 @@ def test_generate_account_payment_uri_with_amount(account: AccountResource, hrp:
 
     intent = identifier.decode_intent(uri.payment_uri, hrp)
     assert intent.account_address
-    assert intent.subaddress
     assert intent.currency_code is None
     assert intent.amount == amount
 
@@ -61,7 +58,6 @@ def test_generate_account_payment_uri_with_currency_and_amount(
 
     intent = identifier.decode_intent(uri.payment_uri, hrp)
     assert intent.account_address
-    assert intent.subaddress
     assert intent.currency_code == currency
     assert intent.amount == amount
 
@@ -82,11 +78,3 @@ def test_generate_account_payment_uri_with_integer_overflow_amount(account: Acco
     amount = 324234324342234234234234242234234324323423432432423423243242342342342342342342342334234
     with pytest.raises(requests.HTTPError, match="400 Client Error"):
         account.generate_payment_uri(amount=amount)
-
-
-def test_generate_account_payment_URI_should_include_unique_subaddress(account: AccountResource, hrp: str) -> None:
-    def subaddress(uri: str) -> str:
-        return utils.hex(identifier.decode_intent(uri, hrp).subaddress)
-
-    subaddresses = [subaddress(account.generate_payment_uri().payment_uri) for _ in range(10)]
-    assert sorted(subaddresses) == sorted(list(set(subaddresses)))

--- a/tests/miniwallet/test_api.py
+++ b/tests/miniwallet/test_api.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from diem.testing.miniwallet import RestClient, Account
+from diem import utils, identifier
 import pytest, requests, json, time
 
 
@@ -120,3 +121,13 @@ def test_create_account_payment_uri_events(target_client: RestClient, hrp: str) 
 def test_openapi_spec(target_client: RestClient) -> None:
     resp = target_client.send("GET", "/openapi.yaml")
     assert resp.text
+
+
+def test_generate_account_payment_URI_should_include_unique_subaddress(target_client: RestClient, hrp: str) -> None:
+    account = target_client.create_account()
+
+    def subaddress(uri: str) -> str:
+        return utils.hex(identifier.decode_intent(uri, hrp).subaddress)
+
+    subaddresses = [subaddress(account.generate_payment_uri().payment_uri) for _ in range(10)]
+    assert sorted(subaddresses) == sorted(list(set(subaddresses)))


### PR DESCRIPTION
A VASP may not need to use subaddress to receive a payment if the child VASP account is one for a specific user / organization account, or parent VASP created one child VASP account per user.
Thus we remove subaddress assertion in the test generating payment URI.
Technically, as long as wallet application can correctly receive a payment by the generated payment URI, then it should be fine.