### PR TITLE
Change to use offchain KycDataObject struct for KYC data fields in mini-wallet API request/response

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ format:
 test: format runtest
 
 runtest:
-	DMW_SELF_CHECK=Y ./venv/bin/pytest src/diem/testing/suites tests examples -k "$(t)" $(args)
+	DMW_SELF_CHECK=Y ./venv/bin/pytest src/diem/testing/suites tests examples --log-level info -k "$(t)" $(args)
 
 profile:
 	./venv/bin/python -m profile -m pytest tests examples -k "$(t)" $(args)

--- a/src/diem/testing/miniwallet/app/api.py
+++ b/src/diem/testing/miniwallet/app/api.py
@@ -47,7 +47,7 @@ class Endpoints:
 
     @rest_handler
     def on_post_accounts(self, input: JsonInput) -> Tuple[str, Dict[str, str]]:
-        return (falcon.HTTP_201, asdict(self.app.create_account(input)))
+        return (falcon.HTTP_201, self.app.create_account(input))
 
     @rest_handler
     def on_post_payments(self, account_id: str, input: JsonInput) -> Tuple[str, Dict[str, Any]]:

--- a/src/diem/testing/miniwallet/app/static/openapi.yaml
+++ b/src/diem/testing/miniwallet/app/static/openapi.yaml
@@ -211,7 +211,7 @@ paths:
             | `created_account`         | JSON-encoded string | An account is created.                                                            |
             | `created_transaction`     | JSON-encoded string | An incoming or outgoing transaction is created.                                   |
             | `updated_transaction`     | JSON-encoded string | Outgoing transactions are updated due to Diem transactions being submitted or executed. |
-            | `created_payment_uri`     | JSON-encoded string | A PaymentURI is created.                                                          |
+            | `created_subaddress`      | JSON-encoded string | A Subaddress is created.                                                          |
             | `created_payment_command` | JSON-encoded string | Off-chain payment command is created.                                             |
             | `updated_payment_command` | JSON-encoded string | Off-chain payment command is updated.                                             |
 
@@ -262,12 +262,6 @@ components:
           example: 1000000000
         XDX:
           type: integer
-    KycDataObject:
-      type: string
-      description: >
-        KycDataObject should be valid object that matches Diem off-chain KycDataObject
-        listed at https://dip.diem.com/dip-1/#kycdataobject.
-      example: "{\"type\": \"individual\", \"payload_version\": 1, \"given_name\": \"Tom\", \"surname\": \"Jack\"}"
     Account:
       required:
       - id
@@ -406,3 +400,81 @@ components:
           description: Milliseconds since the unix epoch. The time event object is
             created by the system.
           readOnly: true
+    KycDataObject:
+      type: object
+      description: >
+          A KycDataObject represents the know your customer or know your client (KYC) data required for exchanging
+          KYC data in Diem off-chain API.
+
+          It matches Diem off-chain KycDataObject listed at https://dip.diem.com/dip-1/#kycdataobject.
+      example: {"type": "individual", "payload_version": 1, "given_name": "Tom", "surname": "Jack"}
+      required:
+        - payload_version
+        - type
+      properties:
+        payload_version:
+          type: string
+          description: >-
+              Version identifier to allow modifications to KYC data Object without needing to bump version of entire API set. Set to 1
+        type:
+          type: string
+          enum: ["individual", "entity"]
+        given_name:
+          type: string
+          description: Legal given name of the user for which this KYC data Object applies.
+        surname:
+          type: string
+          description: Legal surname of the user for which this KYC data Object applies.
+        address:
+          description: Physical address data for this account
+          $ref: '#/components/schemas/Address'
+        dob:
+          type: string
+          description: >-
+              Date of birth for the holder of this account. Specified as an ISO 8601 calendar date format: https://en.wikipedia.org/wiki/ISO_8601
+        place_of_birth:
+          description: Place of birth for this user. line1 and line2 fields should not be populated for this usage of the address Object
+          $ref: '#/components/schemas/Address'
+        national_id:
+          $ref: '#/components/schemas/NationalId'
+        legal_entity_name:
+          type: string
+          description: >-
+              Name of the legal entity. Used when subaddress represents a legal entity rather than an individual.
+              KycData should only include one of legal_entity_name OR given_name/surname
+    Address:
+      type: object
+      properties:
+        city:
+          type: string
+          description: The city, district, suburb, town, or village
+        country:
+          type: string
+          description: Two-letter country code (https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)
+        line1:
+          type: string
+          description: Address line 1
+        line2:
+          type: string
+          description: Address line 2 - apartment, unit, etc.
+        postal_code:
+          type: string
+          description: ZIP or postal code
+        state:
+          type: string
+          description: State, county, province, region.
+    NationalId:
+      type: object
+      required:
+        - id_value
+      description: National ID information for the holder of this account
+      properties:
+        id_value:
+          type: string
+          description: Indicates the national ID value - for example, a social security number
+        county:
+          type: string
+          description: Two-letter country code (https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)
+        type:
+          type: string
+          description: Indicates the type of the ID

--- a/src/diem/testing/suites/test_create_test_account.py
+++ b/src/diem/testing/suites/test_create_test_account.py
@@ -24,11 +24,13 @@ def test_create_an_account_with_initial_deposit_balances(target_client: RestClie
 @pytest.mark.parametrize(  # pyre-ignore
     "kyc_data",
     [
-        offchain.to_json(offchain.individual_kyc_data()),
-        offchain.to_json(offchain.entity_kyc_data()),
+        offchain.individual_kyc_data(),
+        offchain.entity_kyc_data(),
     ],
 )
-def test_create_an_account_with_minimum_valid_kyc_data(target_client: RestClient, kyc_data: str) -> None:
+def test_create_an_account_with_minimum_valid_kyc_data(
+    target_client: RestClient, kyc_data: offchain.KycDataObject
+) -> None:
     account = target_client.create_account(kyc_data=kyc_data)
     assert account.id
 
@@ -36,7 +38,7 @@ def test_create_an_account_with_minimum_valid_kyc_data(target_client: RestClient
 def test_create_an_account_with_valid_kyc_data_and_initial_deposit_balances(
     target_client: RestClient, currency: str
 ) -> None:
-    minimum_kyc_data = offchain.to_json(offchain.individual_kyc_data())
+    minimum_kyc_data = offchain.individual_kyc_data()
     account = target_client.create_account(kyc_data=minimum_kyc_data, balances={currency: 123})
     assert account.id
 

--- a/src/diem/testing/suites/test_offchain_protocol_error_cases.py
+++ b/src/diem/testing/suites/test_offchain_protocol_error_cases.py
@@ -1,6 +1,7 @@
 # Copyright (c) The Diem Core Contributors
 # SPDX-License-Identifier: Apache-2.0
 
+from dataclasses import asdict
 from diem import identifier, jsonrpc, offchain, testnet
 from diem.testing import LocalAccount
 from diem.testing.miniwallet import RestClient, AppConfig
@@ -32,7 +33,7 @@ def test_invalid_x_request_id(
     sender_address = stub_client.create_account().generate_account_identifier(hrp)
     request = payment_command_request_sample(
         sender_address=sender_address,
-        sender_kyc_data=json.loads(target_client.new_kyc_data(sample="minimum")),
+        sender_kyc_data=target_client.new_kyc_data(sample="minimum"),
         receiver_address=receiver_address,
         currency=currency,
         amount=travel_rule_threshold,
@@ -74,7 +75,7 @@ def test_missing_x_request_id(
     sender_address = stub_client.create_account().generate_account_identifier(hrp)
     request = payment_command_request_sample(
         sender_address=sender_address,
-        sender_kyc_data=json.loads(target_client.new_kyc_data(sample="minimum")),
+        sender_kyc_data=target_client.new_kyc_data(sample="minimum"),
         receiver_address=receiver_address,
         currency=currency,
         amount=travel_rule_threshold,
@@ -125,7 +126,7 @@ def test_invalid_x_request_sender_address(
     sender_address = stub_client.create_account().generate_account_identifier(hrp)
     request = payment_command_request_sample(
         sender_address=sender_address,
-        sender_kyc_data=json.loads(target_client.new_kyc_data(sample="minimum")),
+        sender_kyc_data=target_client.new_kyc_data(sample="minimum"),
         receiver_address=receiver_address,
         currency=currency,
         amount=travel_rule_threshold,
@@ -166,7 +167,7 @@ def test_missing_x_request_sender_address(
     sender_address = stub_client.create_account().generate_account_identifier(hrp)
     request = payment_command_request_sample(
         sender_address=sender_address,
-        sender_kyc_data=json.loads(target_client.new_kyc_data(sample="minimum")),
+        sender_kyc_data=target_client.new_kyc_data(sample="minimum"),
         receiver_address=receiver_address,
         currency=currency,
         amount=travel_rule_threshold,
@@ -207,7 +208,7 @@ def test_x_request_sender_is_valid_but_no_compliance_key(
     sender_address = new_stub_account.account_identifier()
     request = payment_command_request_sample(
         sender_address=sender_address,
-        sender_kyc_data=json.loads(target_client.new_kyc_data(sample="minimum")),
+        sender_kyc_data=target_client.new_kyc_data(sample="minimum"),
         receiver_address=receiver_address,
         currency=currency,
         amount=travel_rule_threshold,
@@ -249,7 +250,7 @@ def test_invalid_jws_message_body_that_misses_parts(
     sender_address = stub_client.create_account().generate_account_identifier(hrp)
     request = payment_command_request_sample(
         sender_address=sender_address,
-        sender_kyc_data=json.loads(target_client.new_kyc_data(sample="minimum")),
+        sender_kyc_data=target_client.new_kyc_data(sample="minimum"),
         receiver_address=receiver_address,
         currency=currency,
         amount=travel_rule_threshold,
@@ -295,7 +296,7 @@ def test_invalid_jws_message_signature(
     sender_address = new_stub_account.account_identifier()
     request = payment_command_request_sample(
         sender_address=sender_address,
-        sender_kyc_data=json.loads(target_client.new_kyc_data(sample="minimum")),
+        sender_kyc_data=target_client.new_kyc_data(sample="minimum"),
         receiver_address=receiver_address,
         currency=currency,
         amount=travel_rule_threshold,
@@ -346,7 +347,7 @@ def send_request_json(
 
 
 def payment_command_request_sample(
-    sender_address: str, sender_kyc_data: Dict[str, Any], receiver_address: str, currency: str, amount: int
+    sender_address: str, sender_kyc_data: offchain.KycDataObject, receiver_address: str, currency: str, amount: int
 ) -> Dict[str, Any]:
     """Creates a `PaymentCommand` initial state request JSON object (dictionary).
 
@@ -366,7 +367,7 @@ def payment_command_request_sample(
                 "sender": {
                     "address": sender_address,
                     "status": {"status": "needs_kyc_data"},
-                    "kyc_data": sender_kyc_data,
+                    "kyc_data": asdict(sender_kyc_data),
                 },
                 "receiver": {
                     "address": receiver_address,

--- a/tests/miniwallet/test_api.py
+++ b/tests/miniwallet/test_api.py
@@ -3,6 +3,7 @@
 
 from diem.testing.miniwallet import RestClient, Account
 from diem import utils, identifier
+from typing import Dict, Any
 import pytest, requests, json, time
 
 
@@ -17,14 +18,13 @@ def test_create_account_with_balances_and_kyc_data(target_client: RestClient, cu
 @pytest.mark.parametrize(
     "kyc_data",
     [
-        "invalid json",
-        '{"type": "individual"}',
-        '{"type": "entity"}',
-        '{"payload_version": 1}',
-        '{"type": "individual", "payload_version": "1"}',
+        {"type": "individual"},
+        {"type": "entity"},
+        {"payload_version": 1},
+        {"type": "individual", "payload_version": "1"},
     ],
 )
-def test_create_an_account_with_invalid_kyc_data(target_client: RestClient, kyc_data: str) -> None:
+def test_create_an_account_with_invalid_kyc_data(target_client: RestClient, kyc_data: Dict[str, Any]) -> None:
     with pytest.raises(requests.exceptions.HTTPError, match="400 Client Error") as einfo:
         target_client.create("/accounts", kyc_data=kyc_data)
 
@@ -80,7 +80,7 @@ def test_account_balance_validation_should_exclude_canceled_transactions(
     amount = travel_rule_threshold
     receiver = target_client.create_account()
     payment_uri = receiver.generate_payment_uri()
-    sender = stub_client.create_account({currency: amount}, kyc_data=target_client.new_reject_kyc_data())
+    sender = stub_client.create_account({currency: amount}, kyc_data=target_client.new_kyc_data(sample="reject"))
     # payment should be rejected during offchain kyc data exchange
     payment = sender.send_payment(currency, amount, payee=payment_uri.intent(hrp).account_id)
 

--- a/tests/miniwallet/test_models.py
+++ b/tests/miniwallet/test_models.py
@@ -9,7 +9,7 @@ from diem import offchain
 
 def test_match_kyc_data():
     ks = KycSample.gen("foo")
-    obj = offchain.from_json(ks.soft_match, offchain.KycDataObject)
+    obj = ks.soft_match
     assert ks.match_kyc_data("soft_match", obj)
     assert not ks.match_kyc_data("reject", obj)
 
@@ -26,7 +26,7 @@ def test_decode_account_kyc_data():
     sample = KycSample.gen("foo")
     account = Account(id="1", kyc_data=sample.minimum)
     assert account.kyc_data_object()
-    assert offchain.to_json(account.kyc_data_object()) == sample.minimum
+    assert account.kyc_data_object() == sample.minimum
 
 
 def test_payment_uri_intent_identifier():


### PR DESCRIPTION
From user's feedback, use defined KycDataObject struct instead of JSON-encoded string for the kyc data fields in the request / response, simplify the serialization and deserialization of the request / response objects.