### PR TITLE
make account events api enabled by default

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,6 @@ pyre-check==0.0.58
 pytest-cov
 mypy-protobuf
 pdoc3
-falcon
+falcon==2.0.0
 waitress
 pygount

--- a/src/diem/testing/cli.py
+++ b/src/diem/testing/cli.py
@@ -35,7 +35,7 @@ def main() -> None:
 @click.option("--port", "-p", default=8888, help="Start server port.")
 @click.option("--jsonrpc", "-j", default=testnet.JSON_RPC_URL, help="Diem fullnode JSON-RPC URL.")
 @click.option("--faucet", "-f", default=testnet.FAUCET_URL, help="Testnet faucet URL.")
-@click.option("--enable-debug-api", "-o", default=True, help="Enable debug API.", type=bool, is_flag=True)
+@click.option("--disable-events-api", "-o", default=False, help="Disable account events API.", type=bool, is_flag=True)
 @click.option(
     "--logfile", "-l", default=None, type=click.Path(), help="Log to a file instead of printing into console."
 )
@@ -52,14 +52,14 @@ def start_server(
     port: int,
     jsonrpc: str,
     faucet: str,
-    enable_debug_api: bool,
+    disable_events_api: bool,
     import_diem_account_config_file: Optional[TextIO],
     logfile: Optional[str],
 ) -> None:
     logging.basicConfig(level=logging.INFO, format=log_format, filename=logfile)
     configure_testnet(jsonrpc, faucet)
 
-    conf = AppConfig(name=name, server_conf=ServerConfig(host=host, port=port), enable_debug_api=enable_debug_api)
+    conf = AppConfig(name=name, server_conf=ServerConfig(host=host, port=port), disable_events_api=disable_events_api)
     if import_diem_account_config_file:
         conf.account_config = json.load(import_diem_account_config_file)
 
@@ -110,15 +110,6 @@ def start_server(
     show_default=False,
 )
 @click.option(
-    "--test-debug-api",
-    "-d",
-    default=False,
-    is_flag=True,
-    callback=set_env(envs.TEST_DEBUG_API),
-    help="Run tests for debug APIs.",
-    type=bool,
-)
-@click.option(
     "--logfile", "-l", default=None, help="Log to a file instead of printing into console.", type=click.Path()
 )
 @click.option("--verbose", "-v", default=False, help="Enable verbose log output.", type=bool, is_flag=True)
@@ -138,7 +129,6 @@ def test(
     jsonrpc: str,
     faucet: str,
     pytest_args: str,
-    test_debug_api: bool,
     logfile: Optional[str],
     verbose: bool,
     import_stub_diem_account_config_file: Optional[TextIO],

--- a/src/diem/testing/miniwallet/app/api.py
+++ b/src/diem/testing/miniwallet/app/api.py
@@ -95,15 +95,16 @@ class Endpoints:
         raise falcon.HTTPMovedPermanently("/index.html")
 
 
-def falcon_api(app: App, enable_debug_api: bool = False) -> falcon.API:
+def falcon_api(app: App, disable_events_api: bool = False) -> falcon.API:
     endpoints = Endpoints(app=app)
     api = falcon.API(middleware=[LoggerMiddleware(logger=app.logger)])
     api.add_static_route("/", base_path)
     api.add_route("/", endpoints, suffix="index")
     api.add_route("/accounts", endpoints, suffix="accounts")
     for res in ["balances", "payments", "payment_uris", "events"]:
-        if res != "events" or enable_debug_api:
-            api.add_route("/accounts/{account_id}/%s" % res, endpoints, suffix=res)
+        if res == "events" and disable_events_api:
+            continue
+        api.add_route("/accounts/{account_id}/%s" % res, endpoints, suffix=res)
     api.add_route("/kyc_sample", endpoints, suffix="kyc_sample")
     api.add_route("/v2/command", endpoints, suffix="offchain")
     app.start_sync()

--- a/src/diem/testing/miniwallet/config.py
+++ b/src/diem/testing/miniwallet/config.py
@@ -24,7 +24,7 @@ class ServerConfig:
 @dataclass
 class AppConfig:
     name: str = field(default="mini-wallet")
-    enable_debug_api: bool = field(default=False)
+    disable_events_api: bool = field(default=False)
     account_config: Dict[str, Any] = field(default_factory=lambda: LocalAccount().to_dict())
     server_conf: ServerConfig = field(default_factory=ServerConfig)
     initial_amount: int = field(default=1_000_000_000_000)
@@ -73,7 +73,7 @@ class AppConfig:
         return False
 
     def serve(self, client: jsonrpc.Client) -> threading.Thread:
-        api: falcon.API = falcon_api(App(self.account, client, self.name, self.logger), self.enable_debug_api)
+        api: falcon.API = falcon_api(App(self.account, client, self.name, self.logger), self.disable_events_api)
 
         def serve() -> None:
             self.logger.info("serving on %s:%s at %s", self.server_conf.host, self.server_conf.port, self.server_url)

--- a/src/diem/testing/suites/conftest.py
+++ b/src/diem/testing/suites/conftest.py
@@ -8,7 +8,6 @@ from ..miniwallet.app.event_puller import PENDING_INBOUND_ACCOUNT_ID
 from .envs import (
     target_url,
     is_self_check,
-    should_test_debug_api,
     dmw_stub_server,
     dmw_stub_diem_account_config,
 )
@@ -18,7 +17,7 @@ import pytest, json
 @pytest.fixture(scope="package")
 def target_client(diem_client: jsonrpc.Client) -> RestClient:
     if is_self_check():
-        conf = AppConfig(name="target-wallet", enable_debug_api=should_test_debug_api())
+        conf = AppConfig(name="target-wallet")
         print("self-checking, launch target app with config %s" % conf)
         conf.start(diem_client)
         return conf.create_client()
@@ -35,7 +34,7 @@ def diem_client() -> jsonrpc.Client:
 
 @pytest.fixture(scope="package")
 def stub_config() -> AppConfig:
-    conf = AppConfig(name="stub-wallet", enable_debug_api=True, server_conf=ServerConfig(**dmw_stub_server()))
+    conf = AppConfig(name="stub-wallet", server_conf=ServerConfig(**dmw_stub_server()))
     account_conf = dmw_stub_diem_account_config()
     if account_conf:
         print("loads stub account config: %s" % account_conf)

--- a/src/diem/testing/suites/envs.py
+++ b/src/diem/testing/suites/envs.py
@@ -6,7 +6,6 @@ from typing import Optional, Dict, Any
 
 
 TARGET_URL: str = "DMW_TEST_TARGET"
-TEST_DEBUG_API: str = "DMW_TEST_DEBUG_API"
 SELF_CHECK: str = "DMW_SELF_CHECK"
 
 DMW_STUB_BIND_HOST: str = "DMW_STUB_BIND_HOST"
@@ -51,7 +50,3 @@ def target_url() -> str:
 
 def is_self_check() -> bool:
     return getenv(SELF_CHECK) is not None
-
-
-def should_test_debug_api() -> bool:
-    return getenv(TEST_DEBUG_API) is not None

--- a/tests/miniwallet/conftest.py
+++ b/tests/miniwallet/conftest.py
@@ -38,7 +38,7 @@ def travel_rule_threshold(diem_client: jsonrpc.Client) -> int:
 
 
 def start_app(diem_client: jsonrpc.Client, app_name: str) -> AppConfig:
-    conf = AppConfig(name=app_name, enable_debug_api=True)
+    conf = AppConfig(name=app_name)
     print("launch %s with config %s" % (app_name, conf))
     conf.start(diem_client)
     return conf


### PR DESCRIPTION
1. remove `test_debug_api` environment variable and option.
2. renamed `enable_debug_api` to `disable_events_api`, and changed default value from True to False.
3. lock falcon version to 2.0.0 in test env.