### PR TITLE
add Transaction#type to mini-wallet transaction type

### DIFF
--- a/src/diem/testing/miniwallet/app/event_puller.py
+++ b/src/diem/testing/miniwallet/app/event_puller.py
@@ -95,6 +95,7 @@ class EventPuller:
             Transaction,
             account_id=PENDING_INBOUND_ACCOUNT_ID,
             status=Transaction.Status.pending,
+            type=Transaction.Type.sent_payment,
             currency=event.data.amount.currency,
             amount=event.data.amount.amount,
             payee=payee,
@@ -111,5 +112,6 @@ class EventPuller:
             amount=event.data.amount.amount,
             diem_transaction_version=event.transaction_version,
             status=Transaction.Status.completed,
+            type=Transaction.Type.received_payment,
             **kwargs,
         )

--- a/src/diem/testing/miniwallet/app/models.py
+++ b/src/diem/testing/miniwallet/app/models.py
@@ -96,10 +96,16 @@ class Transaction(Base):
         canceled = "canceled"
         pending = "pending"
 
+    class Type(str, Enum):
+        sent_payment = "sent_payment"
+        received_payment = "received_payment"
+        deposit = "deposit"
+
     account_id: str
     currency: str
     amount: int
     status: Status
+    type: Type
     cancel_reason: Optional[str] = field(default=None)
     payee: Optional[str] = field(default=None)
     subaddress_hex: Optional[str] = field(default=None)

--- a/tests/miniwallet/test_models.py
+++ b/tests/miniwallet/test_models.py
@@ -40,7 +40,14 @@ def test_payment_uri_intent_identifier():
 
 
 def test_transaction_balance_amount():
-    txn = Transaction(id="1", account_id="2", currency="XUS", amount=1000, status=Transaction.Status.pending)
+    txn = Transaction(
+        id="1",
+        account_id="2",
+        currency="XUS",
+        amount=1000,
+        status=Transaction.Status.pending,
+        type=Transaction.Type.deposit,
+    )
     assert txn.balance_amount() == 1000
 
     txn.payee = "dm1p7ujcndcl7nudzwt8fglhx6wxn08kgs5tm6mz4us2vfufk"
@@ -48,7 +55,14 @@ def test_transaction_balance_amount():
 
 
 def test_transaction_subaddress():
-    txn = Transaction(id="1", account_id="2", currency="XUS", amount=1000, status=Transaction.Status.pending)
+    txn = Transaction(
+        id="1",
+        account_id="2",
+        currency="XUS",
+        amount=1000,
+        status=Transaction.Status.pending,
+        type=Transaction.Type.deposit,
+    )
     txn.subaddress_hex = "cf64428bdeb62af2"
     assert txn.subaddress().hex() == "cf64428bdeb62af2"
 


### PR DESCRIPTION
This is helpful when debugging test failure, the output log or assertion failure may include events related to mini-wallet transactions, adding a type to tell what is type of the transaction can clarify why the transaction is created.