### PR TITLE
add offchain protocol error cases: invalid json or command request object

### DIFF
--- a/src/diem/offchain/types/__init__.py
+++ b/src/diem/offchain/types/__init__.py
@@ -135,7 +135,7 @@ def _field_value_from_dict(field: dataclasses.Field, obj: typing.Any, field_path
     if valid_values:
         if isinstance(valid_values, list) and val not in valid_values:
             raise FieldError(ErrorCode.invalid_field_value, full_name, f"expect one of {valid_values}, but got: {val}")
-        if isinstance(valid_values, re.Pattern) and not valid_values.match(val):
+        if isinstance(val, str) and isinstance(valid_values, re.Pattern) and not valid_values.match(val):
             raise FieldError(
                 ErrorCode.invalid_field_value, full_name, f"{val} does not match pattern {valid_values.pattern}"
             )

--- a/src/diem/testing/miniwallet/app/api.py
+++ b/src/diem/testing/miniwallet/app/api.py
@@ -74,20 +74,9 @@ class Endpoints:
         resp.set_header(offchain.X_REQUEST_ID, request_id)
         request_sender_address = req.get_header(offchain.X_REQUEST_SENDER_ADDRESS)
         input_data = req.stream.read()
-        try:
-            if not request_id:
-                raise offchain.protocol_error(
-                    offchain.ErrorCode.missing_http_header, "missing %s" % offchain.X_REQUEST_ID
-                )
-            if not offchain.UUID_REGEX.match(request_id):
-                raise offchain.protocol_error(
-                    offchain.ErrorCode.invalid_http_header, "invalid %s" % offchain.X_REQUEST_ID
-                )
-            resp_obj = self.app.offchain_api(request_sender_address, input_data)
-        except offchain.Error as e:
-            self.app.logger.info(input_data)
-            self.app.logger.exception(e)
-            resp_obj = offchain.reply_request(cid=None, err=e.obj)
+
+        resp_obj = self.app.offchain_api(request_id, request_sender_address, input_data)
+        if resp_obj.error is not None:
             resp.status = falcon.HTTP_400
         resp.body = self.app.jws_serialize(resp_obj)
 


### PR DESCRIPTION
Added tests for the following cases:
1. decoded JWS message body is invalid json
2. decoded command request object misses required field
3. decoded command request object field value is invalid ("_ObjectType", "cid")
4. decoded command request object command_type is unknown
5. decoded command request object field value type is invalid

Changed some assertions to warning, relax the requirement of return error with exactly same error type, field and code, because some errors can use different code (for example invalid command_type, can use invalid_field_value or unknown_command_type)