### PR TITLE
test suite calls to mini-wallet API with running test case http header

### DIFF
--- a/src/diem/__VERSION__.py
+++ b/src/diem/__VERSION__.py
@@ -1,4 +1,4 @@
 # Copyright (c) The Diem Core Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-VERSION = "1.4.0"
+VERSION = "1.5.0"

--- a/src/diem/testing/miniwallet/app/api.py
+++ b/src/diem/testing/miniwallet/app/api.py
@@ -20,7 +20,9 @@ class LoggerMiddleware:
         self.logger.debug("%s %s", req.method, req.relative_uri)
 
     def process_response(self, req, resp, *args, **kwargs):  # pyre-ignore
-        self.logger.info("%s %s - %s", req.method, req.relative_uri, resp.status)
+        tc = req.get_header("X-Test-Case")
+        test_case = "[%s] " % tc if tc else ""
+        self.logger.info("%s%s %s - %s", test_case, req.method, req.relative_uri, resp.status)
 
 
 def rest_handler(fn: Any):  # pyre-ignore

--- a/src/diem/testing/suites/__init__.py
+++ b/src/diem/testing/suites/__init__.py
@@ -1,2 +1,18 @@
 # Copyright (c) The Diem Core Contributors
 # SPDX-License-Identifier: Apache-2.0
+
+"""This module provides test suites built for verifying the compatibility of a wallet implementing
+[Diem Transactions Specification](https://github.com/diem/diem/tree/main/specifications/transactions).
+
+To test Diem payment transactions integration, the target wallet application should implement [MiniWallet API](https://diem.github.io/client-sdk-python/mini-wallet-api-spec.html), or implementing [MiniWallet API](https://diem.github.io/client-sdk-python/mini-wallet-api-spec.html) as a new http server and proxy the functions to the target wallet application APIs.
+
+HTTP requests from the test suite will have the following custom HTTP headers:
+
+1. X-Test-Case: the current running test case full name; it is `PYTEST_CURRENT_TEST` environment variable value, see [pytest document](https://docs.pytest.org/en/latest/example/simple.html#pytest-current-test-environment-variable) for more details.
+
+Before any tests started, a stub wallet application is configured and started as counterparty wallet application of the target wallet application for wallet to wallet payment tests.
+
+The stub wallet application also implements [MiniWallet API](https://diem.github.io/client-sdk-python/mini-wallet-api-spec.html).
+
+When a test finished, the target wallet application's account events endpoint (`GET /accounts/{account_id}/events`) will be called and the response will be dumped into logs. As the endpoint is optional to implement, we ignore errors and log nothing when calling the endpoint failed.
+"""

--- a/tests/miniwallet/test_client.py
+++ b/tests/miniwallet/test_client.py
@@ -5,20 +5,39 @@
 from diem.testing.miniwallet import RestClient
 from diem import jsonrpc
 from typing import Dict
-import requests
+import requests, os
 
 
-def test_send_with_json_content_type(monkeypatch):
+def test_send_with_json_content_type_user_agent_and_x_test_case(monkeypatch):
+    def send_request(method: str, url: str, data: str, headers: Dict[str, str]) -> requests.Response:
+        assert headers["Content-Type"] == "application/json"
+        assert headers["User-Agent"] == jsonrpc.client.USER_AGENT_HTTP_HEADER
+        assert headers["X-Test-Case"] == os.getenv("PYTEST_CURRENT_TEST")
+        return create_account_response()
+
     session = requests.Session()
+    monkeypatch.setattr(session, "request", send_request)
+    create_account(session)
+
+
+def test_no_x_test_case_for_non_pytest_env(monkeypatch):
+    def send_request(method: str, url: str, data: str, headers: Dict[str, str]) -> requests.Response:
+        assert "X-Test-Case" not in headers
+        return create_account_response()
+
+    session = requests.Session()
+    monkeypatch.setattr(session, "request", send_request)
+    monkeypatch.delenv("PYTEST_CURRENT_TEST")
+    create_account(session)
+
+
+def create_account(session: requests.Session) -> None:
+    client = RestClient(name="name", server_url="server", session=session)
+    client.create_account()
+
+
+def create_account_response() -> requests.Response:
     resp = requests.Response()
     resp.status_code = 200
     resp._content = b'{"id": "1"}'
-
-    def assert_request(method: str, url: str, data: str, headers: Dict[str, str]) -> requests.Response:
-        assert headers["Content-Type"] == "application/json"
-        assert headers["User-Agent"] == jsonrpc.client.USER_AGENT_HTTP_HEADER
-        return resp
-
-    monkeypatch.setattr(session, "request", assert_request)
-    client = RestClient(name="name", server_url="server", session=session)
-    client.create_account()
+    return resp


### PR DESCRIPTION
1. The mini-wallet client used by test suite will send requests with http header `X-Test-Case`, which is set with PYTEST_CURRENT_TEST
2. SDK mini-wallet application will log request info with the `x-test-case` header value