### PR TITLE
mini-wallet app: init child vasp accounts for sending and receiving payments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,6 @@ jobs:
         make dist
   build38:
     runs-on: ubuntu-latest
-    needs: build37
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.8
@@ -55,7 +54,6 @@ jobs:
         make dist
   build39:
     runs-on: ubuntu-latest
-    needs: build38
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.9

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ format:
 test: format runtest
 
 runtest:
-	DMW_SELF_CHECK=Y ./venv/bin/pytest src/diem/testing/suites tests examples --log-level info -k "$(t)" $(args)
+	DMW_SELF_CHECK=Y ./venv/bin/pytest src/diem/testing/suites tests examples --log-level debug -k "$(t)" $(args)
 
 profile:
 	./venv/bin/python -m profile -m pytest tests examples -k "$(t)" $(args)

--- a/src/diem/testing/miniwallet/app/diem_account.py
+++ b/src/diem/testing/miniwallet/app/diem_account.py
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from dataclasses import dataclass
-from typing import Tuple, Optional, Union
+from random import randrange
+from typing import Tuple, Optional, Union, List
 from .models import Transaction, RefundReason
 from ... import LocalAccount
 from .... import jsonrpc, identifier, offchain, stdlib, utils, txnmetadata, diem_types
@@ -11,6 +12,7 @@ from .... import jsonrpc, identifier, offchain, stdlib, utils, txnmetadata, diem
 @dataclass
 class DiemAccount:
     _account: LocalAccount
+    _child_accounts: List[LocalAccount]
     _client: jsonrpc.Client
 
     @property
@@ -21,7 +23,7 @@ class DiemAccount:
         return self._account.compliance_key.sign(msg)
 
     def account_identifier(self, subaddress: Union[str, bytes, None] = None) -> str:
-        return self._account.account_identifier(subaddress)
+        return self._get_payment_account().account_identifier(subaddress)
 
     def decode_account_identifier(self, encoded_id: str) -> Tuple[diem_types.AccountAddress, Optional[bytes]]:
         return identifier.decode_account(encoded_id, self.hrp)
@@ -37,8 +39,13 @@ class DiemAccount:
         metadata = cmd.travel_rule_metadata(self.hrp)
         return (metadata, bytes.fromhex(str(cmd.payment.recipient_signature)))
 
-    def submit_p2p(self, txn: Transaction, metadata: Tuple[bytes, bytes]) -> str:
-        to_account, to_subaddress = identifier.decode_account(str(txn.payee), self.hrp)
+    def submit_p2p(
+        self,
+        txn: Transaction,
+        metadata: Tuple[bytes, bytes],
+        by_address: Optional[diem_types.AccountAddress] = None,
+    ) -> str:
+        to_account = identifier.decode_account_address(str(txn.payee), self.hrp)
         script = stdlib.encode_peer_to_peer_with_metadata_script(
             currency=utils.currency_code(txn.currency),
             amount=txn.amount,
@@ -46,4 +53,17 @@ class DiemAccount:
             metadata=metadata[0],
             metadata_signature=metadata[1],
         )
-        return self._account.submit_txn(self._client, script).bcs_serialize().hex()
+        return self._get_payment_account(by_address).submit_txn(self._client, script).bcs_serialize().hex()
+
+    def _get_payment_account(self, address: Optional[diem_types.AccountAddress] = None) -> LocalAccount:
+        if address is None:
+            if self._child_accounts:
+                return self._child_accounts[randrange(len(self._child_accounts))]
+            return self._account
+        for account in self._child_accounts:
+            if account.account_address == address:
+                return account
+        raise ValueError(
+            "could not find account by address: %s in child accounts: %s"
+            % (address.to_hex(), list(map(lambda a: a.to_dict(), self._child_accounts)))
+        )

--- a/src/diem/testing/miniwallet/app/diem_account.py
+++ b/src/diem/testing/miniwallet/app/diem_account.py
@@ -2,30 +2,43 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from dataclasses import dataclass
-from typing import Tuple
+from typing import Tuple, Optional, Union
 from .models import Transaction, RefundReason
 from ... import LocalAccount
-from .... import jsonrpc, identifier, offchain, stdlib, utils, txnmetadata
+from .... import jsonrpc, identifier, offchain, stdlib, utils, txnmetadata, diem_types
 
 
 @dataclass
 class DiemAccount:
-    account: LocalAccount
-    client: jsonrpc.Client
+    _account: LocalAccount
+    _client: jsonrpc.Client
+
+    @property
+    def hrp(self) -> str:
+        return self._account.hrp
+
+    def sign_by_compliance_key(self, msg: bytes) -> bytes:
+        return self._account.compliance_key.sign(msg)
+
+    def account_identifier(self, subaddress: Union[str, bytes, None] = None) -> str:
+        return self._account.account_identifier(subaddress)
+
+    def decode_account_identifier(self, encoded_id: str) -> Tuple[diem_types.AccountAddress, Optional[bytes]]:
+        return identifier.decode_account(encoded_id, self.hrp)
 
     def refund_metadata(self, version: int, reason: RefundReason) -> Tuple[bytes, bytes]:
         return (txnmetadata.refund_metadata(version, reason.to_diem_type()), b"")
 
     def general_metadata(self, from_subaddress: bytes, payee: str) -> Tuple[bytes, bytes]:
-        to_account, to_subaddress = identifier.decode_account(payee, self.account.hrp)
+        to_account, to_subaddress = identifier.decode_account(payee, self.hrp)
         return (txnmetadata.general_metadata(from_subaddress, to_subaddress), b"")
 
     def travel_metadata(self, cmd: offchain.PaymentCommand) -> Tuple[bytes, bytes]:
-        metadata = cmd.travel_rule_metadata(self.account.hrp)
+        metadata = cmd.travel_rule_metadata(self.hrp)
         return (metadata, bytes.fromhex(str(cmd.payment.recipient_signature)))
 
     def submit_p2p(self, txn: Transaction, metadata: Tuple[bytes, bytes]) -> str:
-        to_account, to_subaddress = identifier.decode_account(str(txn.payee), self.account.hrp)
+        to_account, to_subaddress = identifier.decode_account(str(txn.payee), self.hrp)
         script = stdlib.encode_peer_to_peer_with_metadata_script(
             currency=utils.currency_code(txn.currency),
             amount=txn.amount,
@@ -33,4 +46,4 @@ class DiemAccount:
             metadata=metadata[0],
             metadata_signature=metadata[1],
         )
-        return self.account.submit_txn(self.client, script).bcs_serialize().hex()
+        return self._account.submit_txn(self._client, script).bcs_serialize().hex()

--- a/src/diem/testing/miniwallet/config.py
+++ b/src/diem/testing/miniwallet/config.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from dataclasses import dataclass, field, asdict
-from typing import Dict, Any
+from typing import Dict, Any, List
 from .client import RestClient
 from .app import App, falcon_api
 from .. import LocalAccount
@@ -26,9 +26,11 @@ class AppConfig:
     name: str = field(default="mini-wallet")
     disable_events_api: bool = field(default=False)
     account_config: Dict[str, Any] = field(default_factory=lambda: LocalAccount().to_dict())
+    child_account_configs: List[Dict[str, Any]] = field(default_factory=list)
     server_conf: ServerConfig = field(default_factory=ServerConfig)
-    initial_amount: int = field(default=1_000_000_000_000)
+    initial_amount: int = field(default=3_000_000_000_000)
     initial_currency: str = field(default=testnet.TEST_CURRENCY_CODE)
+    child_account_size: int = field(default=2)
 
     @property
     def logger(self) -> logging.Logger:
@@ -39,6 +41,10 @@ class AppConfig:
         return LocalAccount.from_dict(self.account_config)
 
     @property
+    def child_accounts(self) -> List[LocalAccount]:
+        return list(map(LocalAccount.from_dict, self.child_account_configs))
+
+    @property
     def server_url(self) -> str:
         return self.server_conf.base_url
 
@@ -47,33 +53,26 @@ class AppConfig:
         return RestClient(server_url=self.server_url, name="%s-client" % self.name).with_retry()
 
     def setup_account(self, client: jsonrpc.Client) -> None:
-        acc = client.get_account(self.account.account_address)
-        if not acc or self.need_funds(acc):
-            self.logger.info("faucet mint %s", self.account.account_address.to_hex())
+        if not client.get_account(self.account.account_address):
+            self.logger.info("faucet: mint %s", self.account.account_address.to_hex())
             faucet = testnet.Faucet(client)
             faucet.mint(self.account.auth_key.hex(), self.initial_amount, self.initial_currency)
-        if not acc or self.need_rotate(acc):
+
             self.logger.info("rotate dual attestation info for %s", self.account.account_address.to_hex())
             self.logger.info("set base url to: %s", self.server_url)
             self.account.rotate_dual_attestation_info(client, self.server_url)
 
-    def need_funds(self, account: jsonrpc.Account) -> bool:
-        for balance in account.balances:
-            if balance.currency == self.initial_currency and balance.amount > self.initial_amount / 2:
-                return False
-        return True
-
-    def need_rotate(self, account: jsonrpc.Account) -> bool:
-        if account.role.base_url != self.server_url:
-            return True
-        if not account.role.compliance_key:
-            return True
-        if bytes.fromhex(account.role.compliance_key) != self.account.compliance_public_key_bytes:
-            return True
-        return False
+            self.logger.info("generate child VASP accounts: %s", self.child_account_size)
+            child_account_initial_amount = int(self.initial_amount / (self.child_account_size + 1))
+            for i in range(self.child_account_size):
+                child = self.account.gen_child_vasp(client, child_account_initial_amount, self.initial_currency)
+                self.logger.info("generate child VASP account(%s): %s", i, child.to_dict())
+                self.child_account_configs.append(child.to_dict())
 
     def serve(self, client: jsonrpc.Client) -> threading.Thread:
-        api: falcon.API = falcon_api(App(self.account, client, self.name, self.logger), self.disable_events_api)
+        api: falcon.API = falcon_api(
+            App(self.account, self.child_accounts, client, self.name, self.logger), self.disable_events_api
+        )
 
         def serve() -> None:
             self.logger.info("serving on %s:%s at %s", self.server_conf.host, self.server_conf.port, self.server_url)

--- a/src/diem/testing/suites/test_offchain_protocol_error_cases.py
+++ b/src/diem/testing/suites/test_offchain_protocol_error_cases.py
@@ -1,12 +1,11 @@
 # Copyright (c) The Diem Core Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from dataclasses import asdict
-from diem import identifier, jsonrpc, offchain, testnet
+from diem import jsonrpc, testnet
 from diem.testing import LocalAccount
 from diem.testing.miniwallet import RestClient, AppConfig
-from typing import Dict, Any, Tuple, Optional
-import json, time, requests, uuid, pytest, warnings
+from .conftest import assert_response_error, payment_command_request_sample, send_request_json
+import json, pytest
 
 
 def test_invalid_x_request_id(
@@ -528,84 +527,3 @@ def test_decoded_command_request_object_field_value_type_is_invalid(
     assert status_code == 400
     assert resp.status == "failure"
     assert_response_error(resp, "invalid_field_value", "protocol_error", field=field_name)
-
-
-def send_request_json(
-    diem_client: jsonrpc.Client,
-    sender_account: LocalAccount,
-    sender_address: Optional[str],
-    receiver_address: str,
-    request_json: str,
-    hrp: str,
-    x_request_id: Optional[str] = str(uuid.uuid4()),
-    request_body: Optional[bytes] = None,
-) -> Tuple[int, offchain.CommandResponseObject]:
-    headers = {}
-    if x_request_id:
-        headers[offchain.http_header.X_REQUEST_ID] = x_request_id
-    if sender_address:
-        headers[offchain.http_header.X_REQUEST_SENDER_ADDRESS] = sender_address
-
-    account_address, _ = identifier.decode_account(receiver_address, hrp)
-    base_url, public_key = diem_client.get_base_url_and_compliance_key(account_address)
-    if request_body is None:
-        request_body = offchain.jws.serialize_string(request_json, sender_account.compliance_key.sign)
-    resp = requests.Session().post(
-        f"{base_url.rstrip('/')}/v2/command",
-        data=request_body,
-        headers=headers,
-    )
-
-    cmd_resp_obj = offchain.jws.deserialize(resp.content, offchain.CommandResponseObject, public_key.verify)
-
-    return (resp.status_code, cmd_resp_obj)
-
-
-def payment_command_request_sample(
-    sender_address: str, sender_kyc_data: offchain.KycDataObject, receiver_address: str, currency: str, amount: int
-) -> Dict[str, Any]:
-    """Creates a `PaymentCommand` initial state request JSON object (dictionary).
-
-    Sender address is from the stub wallet application.
-
-    Receiver address is from the target wallet application.
-    """
-
-    return {
-        "_ObjectType": "CommandRequestObject",
-        "cid": str(uuid.uuid4()),
-        "command_type": "PaymentCommand",
-        "command": {
-            "_ObjectType": "PaymentCommand",
-            "payment": {
-                "reference_id": str(uuid.uuid4()),
-                "sender": {
-                    "address": sender_address,
-                    "status": {"status": "needs_kyc_data"},
-                    "kyc_data": asdict(sender_kyc_data),
-                },
-                "receiver": {
-                    "address": receiver_address,
-                    "status": {"status": "none"},
-                },
-                "action": {
-                    "amount": amount,
-                    "currency": currency,
-                    "action": "charge",
-                    "timestamp": int(time.time()),
-                },
-            },
-        },
-    }
-
-
-def assert_response_error(
-    resp: offchain.CommandResponseObject, code: str, err_type: str, field: Optional[str] = None
-) -> None:
-    assert resp.error, resp
-    try:
-        assert resp.error.type == err_type
-        assert resp.error.code == code
-        assert resp.error.field == field
-    except AssertionError as e:
-        warnings.warn(str(e), Warning)

--- a/src/diem/testing/suites/test_payment_command.py
+++ b/src/diem/testing/suites/test_payment_command.py
@@ -1,0 +1,74 @@
+# Copyright (c) The Diem Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from diem import jsonrpc
+from diem.testing.miniwallet import RestClient, AppConfig
+from .conftest import set_field, assert_response_error, payment_command_request_sample, send_request_json
+import json, pytest
+
+
+@pytest.mark.parametrize(
+    "field_name",
+    [
+        "_ObjectType",
+        "payment",
+        "payment.sender",
+        "payment.sender.address",
+        "payment.sender.status",
+        "payment.sender.status.status",
+        "payment.receiver",
+        "payment.receiver.address",
+        "payment.receiver.status",
+        "payment.receiver.status.status",
+        "payment.reference_id",
+        "payment.action",
+        "payment.action.amount",
+        "payment.action.currency",
+        "payment.action.action",
+        "payment.action.timestamp",
+    ],
+)
+def test_payment_command_missing_required_field(
+    stub_config: AppConfig,
+    stub_client: RestClient,
+    target_client: RestClient,
+    diem_client: jsonrpc.Client,
+    currency: str,
+    travel_rule_threshold: int,
+    hrp: str,
+    field_name: str,
+) -> None:
+    """
+    Test Plan:
+
+    1. Create a valid offchain PaymentCommand request object.
+    2. Remove a required field by name defined by the test
+    3. Send the request to the target wallet application offchain API endpoint.
+    4. Expect response status code is 400
+    5. Expect response `CommandResponseObject` with failure status, `command_error` error type,
+       and `missing_field` error code.
+    """
+
+    receiver_address = target_client.create_account().generate_account_identifier()
+    sender_address = stub_client.create_account().generate_account_identifier()
+    request = payment_command_request_sample(
+        sender_address=sender_address,
+        sender_kyc_data=target_client.new_kyc_data(sample="minimum"),
+        receiver_address=receiver_address,
+        currency=currency,
+        amount=travel_rule_threshold,
+    )
+    full_field_name = "command." + field_name
+    set_field(request, full_field_name, None)
+
+    status_code, resp = send_request_json(
+        diem_client,
+        stub_config.account,
+        sender_address,
+        receiver_address,
+        json.dumps(request),
+        hrp,
+    )
+    assert status_code == 400
+    assert resp.status == "failure"
+    assert_response_error(resp, "missing_field", "command_error", field=full_field_name)

--- a/src/diem/testnet.py
+++ b/src/diem/testnet.py
@@ -24,7 +24,7 @@ account: LocalAccount = faucet.gen_account()
 import requests
 import typing
 
-from . import diem_types, jsonrpc, utils, chain_ids, bcs, stdlib, identifier
+from . import diem_types, jsonrpc, utils, chain_ids, bcs, identifier
 from .testing import LocalAccount
 
 
@@ -64,18 +64,7 @@ def gen_child_vasp(
     initial_balance: int = 10_000_000_000,
     currency: str = TEST_CURRENCY_CODE,
 ) -> LocalAccount:
-    child_vasp = LocalAccount.generate()
-    parent_vasp.submit_and_wait_for_txn(
-        client,
-        stdlib.encode_create_child_vasp_account_script(
-            coin_type=utils.currency_code(currency),
-            child_address=child_vasp.account_address,
-            auth_key_prefix=child_vasp.auth_key.prefix(),
-            add_all_currencies=False,
-            child_initial_balance=initial_balance,
-        ),
-    )
-    return child_vasp
+    return parent_vasp.gen_child_vasp(client, initial_balance, currency)
 
 
 class Faucet:

--- a/tests/miniwallet/test_diem_account.py
+++ b/tests/miniwallet/test_diem_account.py
@@ -1,0 +1,41 @@
+# Copyright (c) The Diem Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+
+from diem import testnet, diem_types
+from diem.testing import LocalAccount
+from diem.testing.miniwallet.app import Transaction
+from diem.testing.miniwallet.app.diem_account import DiemAccount
+import pytest
+
+
+def test_no_child_accounts():
+    client = testnet.create_client()
+    account = testnet.gen_account(client)
+    da = DiemAccount(account, [], client)
+    assert da.hrp == account.hrp
+    assert da.account_identifier(None) == account.account_identifier(None)
+
+    signed_txn_hex = da.submit_p2p(gen_txn(), (b"", b""))
+    signed_txn = diem_types.SignedTransaction.bcs_deserialize(bytes.fromhex(signed_txn_hex))
+    assert signed_txn.raw_txn.sender == account.account_address
+
+
+def test_submit_p2p_with_unknown_address():
+    client = testnet.create_client()
+    account = testnet.gen_account(client)
+    da = DiemAccount(account, [], client)
+    with pytest.raises(ValueError):
+        da.submit_p2p(gen_txn(), (b"", b""), by_address=LocalAccount().account_address)
+
+
+def gen_txn() -> Transaction:
+    return Transaction(
+        id="txn",
+        account_id="id",
+        currency="XUS",
+        amount=1,
+        status=Transaction.Status.pending,
+        type=Transaction.Type.sent_payment,
+        payee=LocalAccount().account_identifier(None),
+    )


### PR DESCRIPTION
1. Hide diem account usages in DiemAccount class.
2. Init 2 ChildVASP accounts for mini-wallet application
3. Random pick a child vasp account for sending / receiving payment