### PR TITLE
Fix mini-wallet app for handling replay commands

### DIFF
--- a/src/diem/testing/miniwallet/app/api.py
+++ b/src/diem/testing/miniwallet/app/api.py
@@ -101,5 +101,5 @@ def falcon_api(app: App, disable_events_api: bool = False) -> falcon.API:
         api.add_route("/accounts/{account_id}/%s" % res, endpoints, suffix=res)
     api.add_route("/kyc_sample", endpoints, suffix="kyc_sample")
     api.add_route("/v2/command", endpoints, suffix="offchain")
-    app.start_sync()
+    app.start_bg_worker_thread()
     return api

--- a/src/diem/testing/suites/conftest.py
+++ b/src/diem/testing/suites/conftest.py
@@ -99,13 +99,15 @@ def pending_income_account(stub_client: RestClient) -> AccountResource:
 
 
 @contextmanager
-def disable_stub_bg_tasks(app: App) -> Generator[None, None, None]:
-    app.disable_background_tasks = True
+def disable_background_tasks(app: App) -> Generator[None, None, None]:
+    app.bg_worker = "disable"
+    # wait for status changed from disable to disabled
+    while app.bg_worker == "disable":
+        time.sleep(0.01)
     try:
         yield
     finally:
-        app.disable_background_tasks = False
-        app.start_sync()
+        app.bg_worker = "running"
 
 
 def send_request_json(

--- a/src/diem/testing/suites/test_receive_payment.py
+++ b/src/diem/testing/suites/test_receive_payment.py
@@ -12,9 +12,15 @@ amount: int = 12345
 
 @pytest.fixture
 def sender_account(
-    stub_client: RestClient, currency: str, pending_income_account: AccountResource, travel_rule_threshold: int
+    stub_client: RestClient,
+    currency: str,
+    pending_income_account: AccountResource,
+    travel_rule_threshold: int,
+    target_client: RestClient,
 ) -> Generator[AccountResource, None, None]:
-    account = stub_client.create_account(balances={currency: travel_rule_threshold})
+    account = stub_client.create_account(
+        balances={currency: travel_rule_threshold}, kyc_data=target_client.new_kyc_data(sample="minimum")
+    )
     yield account
     account.log_events()
     # MiniWallet stub saves the payment without account information (subaddress / reference id)
@@ -25,8 +31,8 @@ def sender_account(
 
 
 @pytest.fixture
-def receiver_account(target_client: RestClient) -> Generator[AccountResource, None, None]:
-    account = target_client.create_account()
+def receiver_account(target_client: RestClient, stub_client: RestClient) -> Generator[AccountResource, None, None]:
+    account = target_client.create_account(kyc_data=stub_client.new_kyc_data(sample="minimum"))
     yield account
     account.log_events()
 


### PR DESCRIPTION
Fix mini-wallet app for handling replay commands:
1. Added offchain response cache to wallet app for ensuring same response for the same request cid.

Changes to ensure test_replay_payment_command is more stable and testing with correct KYC sample data:
1. When disabling stub wallet app background tasks, wait for background tasks completely disabled after set the disable flag.
2. Extracted out send_initial_payment_command method for tests to send initial payment command and then re-send the same command, otherwise we may not be able to get back same command if counterparty service updated the payment command.
3. Assign subaddress to transaction when it is created so that send_initial_payment_command don't need worry about subaddress.
4. Wallet app rejects KYC data if it is not match minimum KYC sample.

