### PR TITLE
fix test_invalid_jws_message_signature uses testnet hrp bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ format:
 test: format runtest
 
 runtest:
-	DMW_SELF_CHECK=Y ./venv/bin/pytest src/diem/testing/suites tests examples --log-level debug -k "$(t)" $(args)
+	DMW_SELF_CHECK=Y ./venv/bin/pytest src/diem/testing/suites tests examples --log-level info -k "$(t)" $(args)
 
 profile:
 	./venv/bin/python -m profile -m pytest tests examples -k "$(t)" $(args)

--- a/src/diem/testing/cli.py
+++ b/src/diem/testing/cli.py
@@ -9,7 +9,7 @@ from diem.testing import LocalAccount
 from diem.testing.miniwallet import AppConfig, ServerConfig
 from diem.testing.suites import envs
 from typing import Optional, TextIO
-import logging, click, functools, pytest, os, sys, re, json
+import logging, click, functools, pytest, os, sys, json, shlex
 
 log_format: str = "%(name)s [%(asctime)s] %(levelname)s: %(message)s"
 click.option = functools.partial(click.option, show_default=True)  # pyre-ignore
@@ -139,7 +139,7 @@ def test(
     if stub_bind_host is not None and stub_bind_host != "localhost" and not stub_diem_account_base_url:
         raise click.ClickException("--stub-diem-account-base-url is required when passing in a custom --stub-bind-host")
 
-    args = [arg for arg in re.compile("\\s+").split(pytest_args) if arg]
+    args = shlex.split(pytest_args)
     args = ["--pyargs", "diem.testing.suites"] + args
     if verbose:
         args.append("--log-level=INFO")

--- a/src/diem/testing/suites/test_offchain_protocol_error_cases.py
+++ b/src/diem/testing/suites/test_offchain_protocol_error_cases.py
@@ -288,6 +288,7 @@ def test_invalid_jws_message_signature(
     """
 
     new_stub_account = testnet.gen_account(diem_client)
+    new_stub_account.hrp = hrp
     new_compliance_key = LocalAccount().compliance_public_key_bytes
     new_stub_account.rotate_dual_attestation_info(diem_client, stub_config.server_url, new_compliance_key)
 

--- a/tests/test_testing_cli.py
+++ b/tests/test_testing_cli.py
@@ -66,7 +66,7 @@ def start_test(runner: CliRunner, conf: ServerConfig, options: List[str] = []) -
             "--faucet",
             testnet.FAUCET_URL,
             "--pytest-args",
-            "-k test_receive_payment_with_general_metadata_and_valid_from_and_to_subaddresses",
+            "-k 'test_receive_payment_with_general_metadata_and_valid_from_and_to_subaddresses or test_invalid_jws_message_signature'",
             "--stub-bind-host",
             "0.0.0.0",
             "--stub-bind-port",


### PR DESCRIPTION
When created a new account in the test, we should reset it's hrp with stub wallet application hrp.
Also fixes `dmw` cli `pytest-args` arguments parsing bug, allows use `-k "test_a or test_b"`