### PR TITLE
fix mini-wallet app: validate payment command with prior payment command

### DIFF
--- a/src/diem/__VERSION__.py
+++ b/src/diem/__VERSION__.py
@@ -1,4 +1,4 @@
 # Copyright (c) The Diem Core Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-VERSION = "1.5.1"
+VERSION = "1.5.2"

--- a/src/diem/testing/miniwallet/app/app.py
+++ b/src/diem/testing/miniwallet/app/app.py
@@ -146,7 +146,7 @@ class OffChainAPI(Base):
         try:
             cmd = self.store.find(PaymentCommand, reference_id=new_offchain_cmd.reference_id())
             if new_offchain_cmd != cmd.to_offchain_command():
-                self._update_payment_command(cmd, new_offchain_cmd)
+                self._update_payment_command(cmd, new_offchain_cmd, validate=True)
         except NotFoundError:
             subaddress = utils.hex(new_offchain_cmd.my_subaddress(self.diem_account.hrp))
             account_id = self.store.find(Subaddress, subaddress_hex=subaddress).account_id
@@ -167,9 +167,10 @@ class OffChainAPI(Base):
     def _update_payment_command(
         self, cmd: PaymentCommand, offchain_cmd: offchain.PaymentCommand, validate: bool = False
     ) -> None:
+        prior = cmd.to_offchain_command()
         self.store.update(
             cmd,
-            before_update=lambda _: offchain_cmd.validate(cmd.to_offchain_command()) if validate else None,
+            before_update=lambda _: offchain_cmd.validate(prior) if validate else None,
             cid=offchain_cmd.id(),
             is_inbound=offchain_cmd.is_inbound(),
             is_abort=offchain_cmd.is_abort(),

--- a/src/diem/testing/suites/test_payment_command.py
+++ b/src/diem/testing/suites/test_payment_command.py
@@ -1,8 +1,9 @@
 # Copyright (c) The Diem Core Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from diem import jsonrpc
-from diem.testing.miniwallet import RestClient, AppConfig, App, AccountResource, Transaction
+from dataclasses import replace
+from diem import jsonrpc, offchain, identifier
+from diem.testing.miniwallet import RestClient, AppConfig, App, AccountResource, Transaction, PaymentCommand
 from typing import Union, List, Generator
 from .conftest import (
     set_field,
@@ -312,6 +313,108 @@ def test_replay_the_same_payment_command(
         cmd = stub_wallet_app.send_initial_payment_command(txn)
         stub_wallet_app.send_offchain_command_without_retries(cmd)
         stub_wallet_app.send_offchain_command_without_retries(cmd)
+
+
+def test_payment_command_sender_kyc_data_can_only_be_written_once(
+    currency: str,
+    travel_rule_threshold: int,
+    stub_wallet_app: App,
+    sender_account: AccountResource,
+    receiver_account: AccountResource,
+) -> None:
+    """
+    Test Plan:
+
+    1. Generate a valid account identifier from receiver account as payee.
+    2. Disable stub wallet application background tasks.
+    3. Send a payment requires off-chain PaymentCommand to the receiver account identifier.
+    4. Send initial payment command to receiver wallet offchain API endpoint.
+    5. Wait for receiver's wallet application sends payment command back with receiver ready for settlement.
+    6. Send payment command to receiver with sender ready for settlement and new KYC data.
+    7. Expect response status code is 400
+    8. Expect response `CommandResponseObject` with failure status, `command_error` error type,
+       and `invalid_overwrite` error code.
+    """
+
+    payee = receiver_account.generate_account_identifier()
+
+    with disable_background_tasks(stub_wallet_app):
+        payment = sender_account.send_payment(currency=currency, amount=travel_rule_threshold, payee=payee)
+        txn = stub_wallet_app.store.find(Transaction, id=payment.id)
+        # send initial payment command
+        initial_cmd = stub_wallet_app.send_initial_payment_command(txn)
+
+        # wait for receiver to update payment command
+        sender_account.wait_for_event("updated_payment_command")
+        # find updated payment command
+        updated_cmd = stub_wallet_app.store.find(PaymentCommand, reference_id=initial_cmd.reference_id())
+        offchain_cmd = updated_cmd.to_offchain_command()
+
+        # update sender KYC data
+        assert offchain_cmd.payment.sender.kyc_data
+        if offchain_cmd.payment.sender.kyc_data.dob == "01/01/1979":
+            kyc_data = replace(offchain_cmd.payment.sender.kyc_data, dob="01/01/1979")
+        else:
+            kyc_data = replace(offchain_cmd.payment.sender.kyc_data, dob="01/02/1979")
+        # create new payment command with correct status and changed kyc data
+        new_cmd = offchain_cmd.new_command(status=offchain.Status.ready_for_settlement, kyc_data=kyc_data)
+
+        with pytest.raises(offchain.CommandResponseError) as err:
+            stub_wallet_app.send_offchain_command_without_retries(new_cmd)
+
+        assert_response_error(err.value.resp, "invalid_overwrite", "command_error", field="payment.sender.kyc_data")
+
+
+def test_payment_command_sender_address_can_only_be_written_once(
+    currency: str,
+    travel_rule_threshold: int,
+    stub_wallet_app: App,
+    sender_account: AccountResource,
+    receiver_account: AccountResource,
+    hrp: str,
+) -> None:
+    """
+    Test Plan:
+
+    1. Generate a valid account identifier from receiver account as payee.
+    2. Disable stub wallet application background tasks.
+    3. Send a payment requires off-chain PaymentCommand to the receiver account identifier.
+    4. Send initial payment command to receiver wallet offchain API endpoint.
+    5. Wait for receiver's wallet application sends payment command back with receiver ready for settlement.
+    6. Send payment command to receiver with sender ready for settlement and new sender address.
+    7. Expect response status code is 400
+    8. Expect response `CommandResponseObject` with failure status, `command_error` error type,
+       and `invalid_overwrite` error code.
+    """
+
+    payee = receiver_account.generate_account_identifier()
+
+    with disable_background_tasks(stub_wallet_app):
+        payment = sender_account.send_payment(currency=currency, amount=travel_rule_threshold, payee=payee)
+        txn = stub_wallet_app.store.find(Transaction, id=payment.id)
+        # send initial payment command
+        initial_cmd = stub_wallet_app.send_initial_payment_command(txn)
+
+        # wait for receiver to update payment command
+        sender_account.wait_for_event("updated_payment_command")
+        # find updated payment command
+        updated_cmd = stub_wallet_app.store.find(PaymentCommand, reference_id=initial_cmd.reference_id())
+        offchain_cmd = updated_cmd.to_offchain_command()
+
+        # update sender address
+        sender_account_address = offchain_cmd.sender_account_address(hrp)
+        new_subaddress = stub_wallet_app._gen_subaddress(sender_account.id)
+        new_sender_address = identifier.encode_account(sender_account_address, new_subaddress, hrp)
+        new_sender = replace(offchain_cmd.payment.sender, address=new_sender_address)
+        new_payment = replace(offchain_cmd.payment, sender=new_sender)
+        new_offchain_cmd = replace(offchain_cmd, payment=new_payment, my_actor_address=new_sender_address)
+
+        new_cmd = new_offchain_cmd.new_command(status=offchain.Status.ready_for_settlement)
+
+        with pytest.raises(offchain.CommandResponseError) as err:
+            stub_wallet_app.send_offchain_command_without_retries(new_cmd)
+
+        assert_response_error(err.value.resp, "invalid_overwrite", "command_error", field="payment.sender.address")
 
 
 def assert_payment_command_field_error(


### PR DESCRIPTION
1. Validate payment command with prior payment command was accidentally removed during a refactoring, add the validation back.
2. Added tests for validating with prior payment:
    1. sender.kyc_data can only be written once.
    2. sender.address can only be written once.