### PR TITLE
refactoring tests: inline wallet account creation and replace new_kyc_data with get_kyc_sample for readability

### DIFF
--- a/src/diem/testing/miniwallet/client.py
+++ b/src/diem/testing/miniwallet/client.py
@@ -49,12 +49,12 @@ class RestClient:
         return AccountResource(client=self, id=account["id"], kyc_data=kyc_data)
 
     def new_kyc_data(self, name: Optional[str] = None, sample: str = "minimum") -> offchain.KycDataObject:
-        obj = getattr(self.kyc_sample(), sample)
+        obj = getattr(self.get_kyc_sample(), sample)
         if not name:
             name = "".join(random.choices(string.ascii_uppercase + string.digits, k=6))
         return replace(obj, legal_entity_name=name)
 
-    def kyc_sample(self) -> KycSample:
+    def get_kyc_sample(self) -> KycSample:
         return offchain.from_dict(self.send("GET", "/kyc_sample").json(), KycSample)
 
     def create(self, path: str, **kwargs: Any) -> Dict[str, Any]:

--- a/src/diem/testing/miniwallet/client.py
+++ b/src/diem/testing/miniwallet/client.py
@@ -1,14 +1,14 @@
 # Copyright (c) The Diem Core Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from dataclasses import dataclass, field, replace, asdict
+from dataclasses import dataclass, field, asdict
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 from typing import List, Optional, Any, Dict, Callable
 from .app import KycSample, Event
 from .app.store import _match
 from ... import offchain, jsonrpc
-import requests, logging, random, string, json, time, os
+import requests, logging, json, time, os
 
 
 @dataclass
@@ -47,12 +47,6 @@ class RestClient:
         }
         account = self.create("/accounts", **{k: v for k, v in kwargs.items() if v})
         return AccountResource(client=self, id=account["id"], kyc_data=kyc_data)
-
-    def new_kyc_data(self, name: Optional[str] = None, sample: str = "minimum") -> offchain.KycDataObject:
-        obj = getattr(self.get_kyc_sample(), sample)
-        if not name:
-            name = "".join(random.choices(string.ascii_uppercase + string.digits, k=6))
-        return replace(obj, legal_entity_name=name)
 
     def get_kyc_sample(self) -> KycSample:
         return offchain.from_dict(self.send("GET", "/kyc_sample").json(), KycSample)

--- a/src/diem/testing/suites/conftest.py
+++ b/src/diem/testing/suites/conftest.py
@@ -94,8 +94,20 @@ def travel_rule_threshold(diem_client: jsonrpc.Client) -> int:
 
 
 @pytest.fixture
-def pending_income_account(stub_client: RestClient) -> AccountResource:
+def stub_wallet_pending_income_account(stub_client: RestClient) -> AccountResource:
+    """MiniWallet stub saves the payment without account information (subaddress / reference id)
+    into a pending income account before processing it.
+    """
+
     return AccountResource(id=PENDING_INBOUND_ACCOUNT_ID, client=stub_client)
+
+
+@pytest.fixture(autouse=True)
+def log_stub_wallet_pending_income_account(
+    stub_wallet_pending_income_account: AccountResource,
+) -> Generator[None, None, None]:
+    yield
+    stub_wallet_pending_income_account.log_events()
 
 
 @contextmanager

--- a/src/diem/testing/suites/test_offchain_protocol_error_cases.py
+++ b/src/diem/testing/suites/test_offchain_protocol_error_cases.py
@@ -32,7 +32,7 @@ def test_invalid_x_request_id(
     sender_address = stub_client.create_account().generate_account_identifier()
     request = payment_command_request_sample(
         sender_address=sender_address,
-        sender_kyc_data=target_client.new_kyc_data(sample="minimum"),
+        sender_kyc_data=target_client.get_kyc_sample().minimum,
         receiver_address=receiver_address,
         currency=currency,
         amount=travel_rule_threshold,
@@ -74,7 +74,7 @@ def test_missing_x_request_id(
     sender_address = stub_client.create_account().generate_account_identifier()
     request = payment_command_request_sample(
         sender_address=sender_address,
-        sender_kyc_data=target_client.new_kyc_data(sample="minimum"),
+        sender_kyc_data=target_client.get_kyc_sample().minimum,
         receiver_address=receiver_address,
         currency=currency,
         amount=travel_rule_threshold,
@@ -125,7 +125,7 @@ def test_invalid_x_request_sender_address(
     sender_address = stub_client.create_account().generate_account_identifier()
     request = payment_command_request_sample(
         sender_address=sender_address,
-        sender_kyc_data=target_client.new_kyc_data(sample="minimum"),
+        sender_kyc_data=target_client.get_kyc_sample().minimum,
         receiver_address=receiver_address,
         currency=currency,
         amount=travel_rule_threshold,
@@ -166,7 +166,7 @@ def test_missing_x_request_sender_address(
     sender_address = stub_client.create_account().generate_account_identifier()
     request = payment_command_request_sample(
         sender_address=sender_address,
-        sender_kyc_data=target_client.new_kyc_data(sample="minimum"),
+        sender_kyc_data=target_client.get_kyc_sample().minimum,
         receiver_address=receiver_address,
         currency=currency,
         amount=travel_rule_threshold,
@@ -207,7 +207,7 @@ def test_x_request_sender_is_valid_but_no_compliance_key(
     sender_address = new_stub_account.account_identifier()
     request = payment_command_request_sample(
         sender_address=sender_address,
-        sender_kyc_data=target_client.new_kyc_data(sample="minimum"),
+        sender_kyc_data=target_client.get_kyc_sample().minimum,
         receiver_address=receiver_address,
         currency=currency,
         amount=travel_rule_threshold,
@@ -249,7 +249,7 @@ def test_invalid_jws_message_body_that_misses_parts(
     sender_address = stub_client.create_account().generate_account_identifier()
     request = payment_command_request_sample(
         sender_address=sender_address,
-        sender_kyc_data=target_client.new_kyc_data(sample="minimum"),
+        sender_kyc_data=target_client.get_kyc_sample().minimum,
         receiver_address=receiver_address,
         currency=currency,
         amount=travel_rule_threshold,
@@ -296,7 +296,7 @@ def test_invalid_jws_message_signature(
     sender_address = new_stub_account.account_identifier()
     request = payment_command_request_sample(
         sender_address=sender_address,
-        sender_kyc_data=target_client.new_kyc_data(sample="minimum"),
+        sender_kyc_data=target_client.get_kyc_sample().minimum,
         receiver_address=receiver_address,
         currency=currency,
         amount=travel_rule_threshold,
@@ -373,7 +373,7 @@ def test_decoded_command_request_object_missing_required_field(
     sender_address = stub_client.create_account().generate_account_identifier()
     request = payment_command_request_sample(
         sender_address=sender_address,
-        sender_kyc_data=target_client.new_kyc_data(sample="minimum"),
+        sender_kyc_data=target_client.get_kyc_sample().minimum,
         receiver_address=receiver_address,
         currency=currency,
         amount=travel_rule_threshold,
@@ -419,7 +419,7 @@ def test_decoded_command_request_object_field_value_is_invalid(
     sender_address = stub_client.create_account().generate_account_identifier()
     request = payment_command_request_sample(
         sender_address=sender_address,
-        sender_kyc_data=target_client.new_kyc_data(sample="minimum"),
+        sender_kyc_data=target_client.get_kyc_sample().minimum,
         receiver_address=receiver_address,
         currency=currency,
         amount=travel_rule_threshold,
@@ -463,7 +463,7 @@ def test_decoded_command_request_object_command_type_is_unknown(
     sender_address = stub_client.create_account().generate_account_identifier()
     request = payment_command_request_sample(
         sender_address=sender_address,
-        sender_kyc_data=target_client.new_kyc_data(sample="minimum"),
+        sender_kyc_data=target_client.get_kyc_sample().minimum,
         receiver_address=receiver_address,
         currency=currency,
         amount=travel_rule_threshold,
@@ -510,7 +510,7 @@ def test_decoded_command_request_object_field_value_type_is_invalid(
     sender_address = stub_client.create_account().generate_account_identifier()
     request = payment_command_request_sample(
         sender_address=sender_address,
-        sender_kyc_data=target_client.new_kyc_data(sample="minimum"),
+        sender_kyc_data=target_client.get_kyc_sample().minimum,
         receiver_address=receiver_address,
         currency=currency,
         amount=travel_rule_threshold,

--- a/src/diem/testing/suites/test_payment_command.py
+++ b/src/diem/testing/suites/test_payment_command.py
@@ -430,7 +430,7 @@ def assert_payment_command_field_error(
     sender_address = stub_client.create_account().generate_account_identifier()
     request = payment_command_request_sample(
         sender_address=sender_address,
-        sender_kyc_data=target_client.new_kyc_data(sample="minimum"),
+        sender_kyc_data=target_client.get_kyc_sample().minimum,
         receiver_address=receiver_address,
         currency=currency,
         amount=travel_rule_threshold,

--- a/src/diem/testing/suites/test_payment_command.py
+++ b/src/diem/testing/suites/test_payment_command.py
@@ -3,8 +3,8 @@
 
 from dataclasses import replace
 from diem import jsonrpc, offchain, identifier
-from diem.testing.miniwallet import RestClient, AppConfig, App, AccountResource, Transaction, PaymentCommand
-from typing import Union, List, Generator
+from diem.testing.miniwallet import RestClient, AppConfig, App, Transaction, PaymentCommand
+from typing import Union, List
 from .conftest import (
     set_field,
     assert_response_error,
@@ -13,33 +13,6 @@ from .conftest import (
     disable_background_tasks,
 )
 import json, pytest
-
-
-@pytest.fixture
-def sender_account(
-    stub_client: RestClient,
-    currency: str,
-    pending_income_account: AccountResource,
-    travel_rule_threshold: int,
-    target_client: RestClient,
-) -> Generator[AccountResource, None, None]:
-    account = stub_client.create_account(
-        balances={currency: travel_rule_threshold}, kyc_data=target_client.new_kyc_data(sample="minimum")
-    )
-    yield account
-    account.log_events()
-    # MiniWallet stub saves the payment without account information (subaddress / reference id)
-    # into a pending income account before process it.
-    # Here we log events of the account for showing more context related to the test
-    # when test failed.
-    pending_income_account.log_events()
-
-
-@pytest.fixture
-def receiver_account(target_client: RestClient, stub_client: RestClient) -> Generator[AccountResource, None, None]:
-    account = target_client.create_account(kyc_data=stub_client.new_kyc_data(sample="minimum"))
-    yield account
-    account.log_events()
 
 
 @pytest.mark.parametrize(
@@ -289,8 +262,8 @@ def test_replay_the_same_payment_command(
     currency: str,
     travel_rule_threshold: int,
     stub_wallet_app: App,
-    sender_account: AccountResource,
-    receiver_account: AccountResource,
+    stub_client: RestClient,
+    target_client: RestClient,
 ) -> None:
     """
     Test Plan:
@@ -304,23 +277,31 @@ def test_replay_the_same_payment_command(
     7. Enable stub wallet application background tasks.
     """
 
-    payee = receiver_account.generate_account_identifier()
+    sender_account = stub_client.create_account(
+        balances={currency: travel_rule_threshold}, kyc_data=target_client.get_kyc_sample().minimum
+    )
+    receiver_account = target_client.create_account(kyc_data=stub_client.get_kyc_sample().minimum)
+    try:
+        payee = receiver_account.generate_account_identifier()
 
-    with disable_background_tasks(stub_wallet_app):
-        payment = sender_account.send_payment(currency=currency, amount=travel_rule_threshold, payee=payee)
-        txn = stub_wallet_app.store.find(Transaction, id=payment.id)
-        # send initial payment command
-        cmd = stub_wallet_app.send_initial_payment_command(txn)
-        stub_wallet_app.send_offchain_command_without_retries(cmd)
-        stub_wallet_app.send_offchain_command_without_retries(cmd)
+        with disable_background_tasks(stub_wallet_app):
+            payment = sender_account.send_payment(currency=currency, amount=travel_rule_threshold, payee=payee)
+            txn = stub_wallet_app.store.find(Transaction, id=payment.id)
+            # send initial payment command
+            cmd = stub_wallet_app.send_initial_payment_command(txn)
+            stub_wallet_app.send_offchain_command_without_retries(cmd)
+            stub_wallet_app.send_offchain_command_without_retries(cmd)
+    finally:
+        receiver_account.log_events()
+        sender_account.log_events()
 
 
 def test_payment_command_sender_kyc_data_can_only_be_written_once(
     currency: str,
     travel_rule_threshold: int,
     stub_wallet_app: App,
-    sender_account: AccountResource,
-    receiver_account: AccountResource,
+    stub_client: RestClient,
+    target_client: RestClient,
 ) -> None:
     """
     Test Plan:
@@ -336,42 +317,50 @@ def test_payment_command_sender_kyc_data_can_only_be_written_once(
        and `invalid_overwrite` error code.
     """
 
-    payee = receiver_account.generate_account_identifier()
+    sender_account = stub_client.create_account(
+        balances={currency: travel_rule_threshold}, kyc_data=target_client.get_kyc_sample().minimum
+    )
+    receiver_account = target_client.create_account(kyc_data=stub_client.get_kyc_sample().minimum)
+    try:
+        payee = receiver_account.generate_account_identifier()
 
-    with disable_background_tasks(stub_wallet_app):
-        payment = sender_account.send_payment(currency=currency, amount=travel_rule_threshold, payee=payee)
-        txn = stub_wallet_app.store.find(Transaction, id=payment.id)
-        # send initial payment command
-        initial_cmd = stub_wallet_app.send_initial_payment_command(txn)
+        with disable_background_tasks(stub_wallet_app):
+            payment = sender_account.send_payment(currency=currency, amount=travel_rule_threshold, payee=payee)
+            txn = stub_wallet_app.store.find(Transaction, id=payment.id)
+            # send initial payment command
+            initial_cmd = stub_wallet_app.send_initial_payment_command(txn)
 
-        # wait for receiver to update payment command
-        sender_account.wait_for_event("updated_payment_command")
-        # find updated payment command
-        updated_cmd = stub_wallet_app.store.find(PaymentCommand, reference_id=initial_cmd.reference_id())
-        offchain_cmd = updated_cmd.to_offchain_command()
+            # wait for receiver to update payment command
+            sender_account.wait_for_event("updated_payment_command")
+            # find updated payment command
+            updated_cmd = stub_wallet_app.store.find(PaymentCommand, reference_id=initial_cmd.reference_id())
+            offchain_cmd = updated_cmd.to_offchain_command()
 
-        # update sender KYC data
-        assert offchain_cmd.payment.sender.kyc_data
-        if offchain_cmd.payment.sender.kyc_data.dob == "01/01/1979":
-            kyc_data = replace(offchain_cmd.payment.sender.kyc_data, dob="01/01/1979")
-        else:
-            kyc_data = replace(offchain_cmd.payment.sender.kyc_data, dob="01/02/1979")
-        # create new payment command with correct status and changed kyc data
-        new_cmd = offchain_cmd.new_command(status=offchain.Status.ready_for_settlement, kyc_data=kyc_data)
+            # update sender KYC data
+            assert offchain_cmd.payment.sender.kyc_data
+            if offchain_cmd.payment.sender.kyc_data.dob == "01/01/1979":
+                kyc_data = replace(offchain_cmd.payment.sender.kyc_data, dob="01/01/1979")
+            else:
+                kyc_data = replace(offchain_cmd.payment.sender.kyc_data, dob="01/02/1979")
+            # create new payment command with correct status and changed kyc data
+            new_cmd = offchain_cmd.new_command(status=offchain.Status.ready_for_settlement, kyc_data=kyc_data)
 
-        with pytest.raises(offchain.CommandResponseError) as err:
-            stub_wallet_app.send_offchain_command_without_retries(new_cmd)
+            with pytest.raises(offchain.CommandResponseError) as err:
+                stub_wallet_app.send_offchain_command_without_retries(new_cmd)
 
-        assert_response_error(err.value.resp, "invalid_overwrite", "command_error", field="payment.sender.kyc_data")
+            assert_response_error(err.value.resp, "invalid_overwrite", "command_error", field="payment.sender.kyc_data")
+    finally:
+        receiver_account.log_events()
+        sender_account.log_events()
 
 
 def test_payment_command_sender_address_can_only_be_written_once(
     currency: str,
     travel_rule_threshold: int,
     stub_wallet_app: App,
-    sender_account: AccountResource,
-    receiver_account: AccountResource,
     hrp: str,
+    stub_client: RestClient,
+    target_client: RestClient,
 ) -> None:
     """
     Test Plan:
@@ -387,34 +376,42 @@ def test_payment_command_sender_address_can_only_be_written_once(
        and `invalid_overwrite` error code.
     """
 
-    payee = receiver_account.generate_account_identifier()
+    sender_account = stub_client.create_account(
+        balances={currency: travel_rule_threshold}, kyc_data=target_client.get_kyc_sample().minimum
+    )
+    receiver_account = target_client.create_account(kyc_data=stub_client.get_kyc_sample().minimum)
+    try:
+        payee = receiver_account.generate_account_identifier()
 
-    with disable_background_tasks(stub_wallet_app):
-        payment = sender_account.send_payment(currency=currency, amount=travel_rule_threshold, payee=payee)
-        txn = stub_wallet_app.store.find(Transaction, id=payment.id)
-        # send initial payment command
-        initial_cmd = stub_wallet_app.send_initial_payment_command(txn)
+        with disable_background_tasks(stub_wallet_app):
+            payment = sender_account.send_payment(currency=currency, amount=travel_rule_threshold, payee=payee)
+            txn = stub_wallet_app.store.find(Transaction, id=payment.id)
+            # send initial payment command
+            initial_cmd = stub_wallet_app.send_initial_payment_command(txn)
 
-        # wait for receiver to update payment command
-        sender_account.wait_for_event("updated_payment_command")
-        # find updated payment command
-        updated_cmd = stub_wallet_app.store.find(PaymentCommand, reference_id=initial_cmd.reference_id())
-        offchain_cmd = updated_cmd.to_offchain_command()
+            # wait for receiver to update payment command
+            sender_account.wait_for_event("updated_payment_command")
+            # find updated payment command
+            updated_cmd = stub_wallet_app.store.find(PaymentCommand, reference_id=initial_cmd.reference_id())
+            offchain_cmd = updated_cmd.to_offchain_command()
 
-        # update sender address
-        sender_account_address = offchain_cmd.sender_account_address(hrp)
-        new_subaddress = stub_wallet_app._gen_subaddress(sender_account.id)
-        new_sender_address = identifier.encode_account(sender_account_address, new_subaddress, hrp)
-        new_sender = replace(offchain_cmd.payment.sender, address=new_sender_address)
-        new_payment = replace(offchain_cmd.payment, sender=new_sender)
-        new_offchain_cmd = replace(offchain_cmd, payment=new_payment, my_actor_address=new_sender_address)
+            # update sender address
+            sender_account_address = offchain_cmd.sender_account_address(hrp)
+            new_subaddress = stub_wallet_app._gen_subaddress(sender_account.id)
+            new_sender_address = identifier.encode_account(sender_account_address, new_subaddress, hrp)
+            new_sender = replace(offchain_cmd.payment.sender, address=new_sender_address)
+            new_payment = replace(offchain_cmd.payment, sender=new_sender)
+            new_offchain_cmd = replace(offchain_cmd, payment=new_payment, my_actor_address=new_sender_address)
 
-        new_cmd = new_offchain_cmd.new_command(status=offchain.Status.ready_for_settlement)
+            new_cmd = new_offchain_cmd.new_command(status=offchain.Status.ready_for_settlement)
 
-        with pytest.raises(offchain.CommandResponseError) as err:
-            stub_wallet_app.send_offchain_command_without_retries(new_cmd)
+            with pytest.raises(offchain.CommandResponseError) as err:
+                stub_wallet_app.send_offchain_command_without_retries(new_cmd)
 
-        assert_response_error(err.value.resp, "invalid_overwrite", "command_error", field="payment.sender.address")
+            assert_response_error(err.value.resp, "invalid_overwrite", "command_error", field="payment.sender.address")
+    finally:
+        receiver_account.log_events()
+        sender_account.log_events()
 
 
 def assert_payment_command_field_error(

--- a/src/diem/testing/suites/test_receive_payment.py
+++ b/src/diem/testing/suites/test_receive_payment.py
@@ -449,9 +449,9 @@ def test_receive_payment_meets_travel_rule_threshold_both_kyc_data_evaluations_a
     receive_payment_meets_travel_rule_threshold(
         sender=stub_client.create_account(
             balances={currency: travel_rule_threshold},
-            kyc_data=target_client.new_kyc_data(sample="minimum"),
+            kyc_data=target_client.get_kyc_sample().minimum,
         ),
-        receiver=target_client.create_account(kyc_data=stub_client.new_kyc_data(sample="minimum")),
+        receiver=target_client.create_account(kyc_data=stub_client.get_kyc_sample().minimum),
         payment_command_states=["S_INIT", "R_SEND", "READY"],
         currency=currency,
         amount=travel_rule_threshold,
@@ -478,9 +478,9 @@ def test_receive_payment_meets_travel_rule_threshold_sender_kyc_data_is_rejected
     receive_payment_meets_travel_rule_threshold(
         sender=stub_client.create_account(
             balances={currency: travel_rule_threshold},
-            kyc_data=target_client.new_kyc_data(sample="reject"),
+            kyc_data=target_client.get_kyc_sample().reject,
         ),
-        receiver=target_client.create_account(kyc_data=stub_client.new_kyc_data(sample="minimum")),
+        receiver=target_client.create_account(kyc_data=stub_client.get_kyc_sample().minimum),
         payment_command_states=["S_INIT", "R_ABORT"],
         currency=currency,
         amount=travel_rule_threshold,
@@ -506,9 +506,9 @@ def test_receive_payment_meets_travel_rule_threshold_receiver_kyc_data_is_reject
     receive_payment_meets_travel_rule_threshold(
         sender=stub_client.create_account(
             balances={currency: travel_rule_threshold},
-            kyc_data=target_client.new_kyc_data(sample="minimum"),
+            kyc_data=target_client.get_kyc_sample().minimum,
         ),
-        receiver=target_client.create_account(kyc_data=stub_client.new_kyc_data(sample="reject")),
+        receiver=target_client.create_account(kyc_data=stub_client.get_kyc_sample().reject),
         payment_command_states=["S_INIT", "R_SEND", "S_ABORT"],
         currency=currency,
         amount=travel_rule_threshold,
@@ -534,9 +534,9 @@ def test_receive_payment_meets_travel_rule_threshold_sender_kyc_data_is_soft_mat
     receive_payment_meets_travel_rule_threshold(
         sender=stub_client.create_account(
             balances={currency: travel_rule_threshold},
-            kyc_data=target_client.new_kyc_data(sample="soft_match"),
+            kyc_data=target_client.get_kyc_sample().soft_match,
         ),
-        receiver=target_client.create_account(kyc_data=stub_client.new_kyc_data(sample="minimum")),
+        receiver=target_client.create_account(kyc_data=stub_client.get_kyc_sample().minimum),
         payment_command_states=["S_INIT", "R_SOFT", "S_SOFT_SEND", "R_SEND", "READY"],
         currency=currency,
         amount=travel_rule_threshold,
@@ -562,9 +562,9 @@ def test_receive_payment_meets_travel_rule_threshold_receiver_kyc_data_is_soft_m
     receive_payment_meets_travel_rule_threshold(
         sender=stub_client.create_account(
             balances={currency: travel_rule_threshold},
-            kyc_data=target_client.new_kyc_data(sample="minimum"),
+            kyc_data=target_client.get_kyc_sample().minimum,
         ),
-        receiver=target_client.create_account(kyc_data=stub_client.new_kyc_data(sample="soft_match")),
+        receiver=target_client.create_account(kyc_data=stub_client.get_kyc_sample().soft_match),
         payment_command_states=["S_INIT", "R_SEND", "S_SOFT", "R_SOFT_SEND", "READY"],
         currency=currency,
         amount=travel_rule_threshold,
@@ -590,9 +590,9 @@ def test_receive_payment_meets_travel_rule_threshold_sender_kyc_data_is_soft_mat
     receive_payment_meets_travel_rule_threshold(
         sender=stub_client.create_account(
             balances={currency: travel_rule_threshold},
-            kyc_data=target_client.new_kyc_data(sample="soft_reject"),
+            kyc_data=target_client.get_kyc_sample().soft_reject,
         ),
-        receiver=target_client.create_account(kyc_data=stub_client.new_kyc_data(sample="minimum")),
+        receiver=target_client.create_account(kyc_data=stub_client.get_kyc_sample().minimum),
         payment_command_states=["S_INIT", "R_SOFT", "S_SOFT_SEND", "R_ABORT"],
         currency=currency,
         amount=travel_rule_threshold,
@@ -618,9 +618,9 @@ def test_receive_payment_meets_travel_rule_threshold_receiver_kyc_data_is_soft_m
     receive_payment_meets_travel_rule_threshold(
         sender=stub_client.create_account(
             balances={currency: travel_rule_threshold},
-            kyc_data=target_client.new_kyc_data(sample="minimum"),
+            kyc_data=target_client.get_kyc_sample().minimum,
         ),
-        receiver=target_client.create_account(kyc_data=stub_client.new_kyc_data(sample="soft_reject")),
+        receiver=target_client.create_account(kyc_data=stub_client.get_kyc_sample().soft_reject),
         payment_command_states=["S_INIT", "R_SEND", "S_SOFT", "R_SOFT_SEND", "S_ABORT"],
         currency=currency,
         amount=travel_rule_threshold,
@@ -647,10 +647,10 @@ def test_receive_payment_meets_travel_rule_threshold_sender_kyc_data_is_soft_mat
     receive_payment_meets_travel_rule_threshold(
         sender=stub_client.create_account(
             balances={currency: travel_rule_threshold},
-            kyc_data=target_client.new_kyc_data(sample="soft_match"),
+            kyc_data=target_client.get_kyc_sample().soft_match,
             reject_additional_kyc_data_request=True,
         ),
-        receiver=target_client.create_account(kyc_data=stub_client.new_kyc_data(sample="minimum")),
+        receiver=target_client.create_account(kyc_data=stub_client.get_kyc_sample().minimum),
         payment_command_states=["S_INIT", "R_SOFT", "S_ABORT"],
         currency=currency,
         amount=travel_rule_threshold,
@@ -676,9 +676,9 @@ def test_receive_payment_meets_travel_rule_threshold_sender_and_receiver_kyc_dat
     receive_payment_meets_travel_rule_threshold(
         sender=stub_client.create_account(
             balances={currency: travel_rule_threshold},
-            kyc_data=target_client.new_kyc_data(sample="soft_match"),
+            kyc_data=target_client.get_kyc_sample().soft_match,
         ),
-        receiver=target_client.create_account(kyc_data=stub_client.new_kyc_data(sample="soft_match")),
+        receiver=target_client.create_account(kyc_data=stub_client.get_kyc_sample().soft_match),
         payment_command_states=["S_INIT", "R_SOFT", "S_SOFT_SEND", "R_SEND", "S_SOFT", "R_SOFT_SEND", "READY"],
         currency=currency,
         amount=travel_rule_threshold,
@@ -704,9 +704,9 @@ def test_receive_payment_meets_travel_rule_threshold_sender_kyc_data_is_soft_mat
     receive_payment_meets_travel_rule_threshold(
         sender=stub_client.create_account(
             balances={currency: travel_rule_threshold},
-            kyc_data=target_client.new_kyc_data(sample="soft_match"),
+            kyc_data=target_client.get_kyc_sample().soft_match,
         ),
-        receiver=target_client.create_account(kyc_data=stub_client.new_kyc_data(sample="reject")),
+        receiver=target_client.create_account(kyc_data=stub_client.get_kyc_sample().reject),
         payment_command_states=["S_INIT", "R_SOFT", "S_SOFT_SEND", "R_SEND", "S_ABORT"],
         currency=currency,
         amount=travel_rule_threshold,
@@ -732,9 +732,9 @@ def test_receive_payment_meets_travel_rule_threshold_sender_kyc_data_is_soft_mat
     receive_payment_meets_travel_rule_threshold(
         sender=stub_client.create_account(
             balances={currency: travel_rule_threshold},
-            kyc_data=target_client.new_kyc_data(sample="soft_match"),
+            kyc_data=target_client.get_kyc_sample().soft_match,
         ),
-        receiver=target_client.create_account(kyc_data=stub_client.new_kyc_data(sample="soft_reject")),
+        receiver=target_client.create_account(kyc_data=stub_client.get_kyc_sample().soft_reject),
         payment_command_states=["S_INIT", "R_SOFT", "S_SOFT_SEND", "R_SEND", "S_SOFT", "R_SOFT_SEND", "S_ABORT"],
         currency=currency,
         amount=travel_rule_threshold,

--- a/src/diem/testing/suites/test_send_payment.py
+++ b/src/diem/testing/suites/test_send_payment.py
@@ -279,9 +279,9 @@ def test_send_payment_meets_travel_rule_threshold_both_kyc_data_evaluations_are_
 
     send_payment_meets_travel_rule_threshold(
         sender=target_client.create_account(
-            balances={currency: travel_rule_threshold}, kyc_data=stub_client.new_kyc_data(sample="minimum")
+            balances={currency: travel_rule_threshold}, kyc_data=stub_client.get_kyc_sample().minimum
         ),
-        receiver=stub_client.create_account(kyc_data=target_client.new_kyc_data(sample="minimum")),
+        receiver=stub_client.create_account(kyc_data=target_client.get_kyc_sample().minimum),
         payment_command_states=["S_INIT", "R_SEND", "READY"],
         currency=currency,
         amount=travel_rule_threshold,
@@ -306,9 +306,9 @@ def test_send_payment_meets_travel_rule_threshold_sender_kyc_data_is_rejected_by
 
     send_payment_meets_travel_rule_threshold(
         sender=target_client.create_account(
-            balances={currency: travel_rule_threshold}, kyc_data=stub_client.new_kyc_data(sample="reject")
+            balances={currency: travel_rule_threshold}, kyc_data=stub_client.get_kyc_sample().reject
         ),
-        receiver=stub_client.create_account(kyc_data=target_client.new_kyc_data(sample="minimum")),
+        receiver=stub_client.create_account(kyc_data=target_client.get_kyc_sample().minimum),
         payment_command_states=["S_INIT", "R_ABORT"],
         currency=currency,
         amount=travel_rule_threshold,
@@ -333,9 +333,9 @@ def test_send_payment_meets_travel_rule_threshold_receiver_kyc_data_is_rejected_
 
     send_payment_meets_travel_rule_threshold(
         sender=target_client.create_account(
-            balances={currency: travel_rule_threshold}, kyc_data=stub_client.new_kyc_data(sample="minimum")
+            balances={currency: travel_rule_threshold}, kyc_data=stub_client.get_kyc_sample().minimum
         ),
-        receiver=stub_client.create_account(kyc_data=target_client.new_kyc_data(sample="reject")),
+        receiver=stub_client.create_account(kyc_data=target_client.get_kyc_sample().reject),
         payment_command_states=["S_INIT", "R_SEND", "S_ABORT"],
         currency=currency,
         amount=travel_rule_threshold,
@@ -360,9 +360,9 @@ def test_send_payment_meets_travel_rule_threshold_sender_kyc_data_is_soft_match_
 
     send_payment_meets_travel_rule_threshold(
         sender=target_client.create_account(
-            balances={currency: travel_rule_threshold}, kyc_data=stub_client.new_kyc_data(sample="soft_match")
+            balances={currency: travel_rule_threshold}, kyc_data=stub_client.get_kyc_sample().soft_match
         ),
-        receiver=stub_client.create_account(kyc_data=target_client.new_kyc_data(sample="minimum")),
+        receiver=stub_client.create_account(kyc_data=target_client.get_kyc_sample().minimum),
         payment_command_states=["S_INIT", "R_SOFT", "S_SOFT_SEND", "R_SEND", "READY"],
         currency=currency,
         amount=travel_rule_threshold,
@@ -387,9 +387,9 @@ def test_send_payment_meets_travel_rule_threshold_receiver_kyc_data_is_soft_matc
 
     send_payment_meets_travel_rule_threshold(
         sender=target_client.create_account(
-            balances={currency: travel_rule_threshold}, kyc_data=stub_client.new_kyc_data(sample="minimum")
+            balances={currency: travel_rule_threshold}, kyc_data=stub_client.get_kyc_sample().minimum
         ),
-        receiver=stub_client.create_account(kyc_data=target_client.new_kyc_data(sample="soft_match")),
+        receiver=stub_client.create_account(kyc_data=target_client.get_kyc_sample().soft_match),
         payment_command_states=["S_INIT", "R_SEND", "S_SOFT", "R_SOFT_SEND", "READY"],
         currency=currency,
         amount=travel_rule_threshold,
@@ -414,9 +414,9 @@ def test_send_payment_meets_travel_rule_threshold_sender_kyc_data_is_soft_match_
 
     send_payment_meets_travel_rule_threshold(
         sender=target_client.create_account(
-            balances={currency: travel_rule_threshold}, kyc_data=stub_client.new_kyc_data(sample="soft_reject")
+            balances={currency: travel_rule_threshold}, kyc_data=stub_client.get_kyc_sample().soft_reject
         ),
-        receiver=stub_client.create_account(kyc_data=target_client.new_kyc_data(sample="minimum")),
+        receiver=stub_client.create_account(kyc_data=target_client.get_kyc_sample().minimum),
         payment_command_states=["S_INIT", "R_SOFT", "S_SOFT_SEND", "R_ABORT"],
         currency=currency,
         amount=travel_rule_threshold,
@@ -441,9 +441,9 @@ def test_send_payment_meets_travel_rule_threshold_receiver_kyc_data_is_soft_matc
 
     send_payment_meets_travel_rule_threshold(
         sender=target_client.create_account(
-            balances={currency: travel_rule_threshold}, kyc_data=stub_client.new_kyc_data(sample="minimum")
+            balances={currency: travel_rule_threshold}, kyc_data=stub_client.get_kyc_sample().minimum
         ),
-        receiver=stub_client.create_account(kyc_data=target_client.new_kyc_data(sample="soft_reject")),
+        receiver=stub_client.create_account(kyc_data=target_client.get_kyc_sample().soft_reject),
         payment_command_states=["S_INIT", "R_SEND", "S_SOFT", "R_SOFT_SEND", "S_ABORT"],
         currency=currency,
         amount=travel_rule_threshold,
@@ -469,10 +469,10 @@ def test_send_payment_meets_travel_rule_threshold_sender_kyc_data_is_soft_match_
 
     send_payment_meets_travel_rule_threshold(
         sender=target_client.create_account(
-            balances={currency: travel_rule_threshold}, kyc_data=stub_client.new_kyc_data(sample="minimum")
+            balances={currency: travel_rule_threshold}, kyc_data=stub_client.get_kyc_sample().minimum
         ),
         receiver=stub_client.create_account(
-            kyc_data=target_client.new_kyc_data(sample="soft_match"), reject_additional_kyc_data_request=True
+            kyc_data=target_client.get_kyc_sample().soft_match, reject_additional_kyc_data_request=True
         ),
         payment_command_states=["S_INIT", "R_SEND", "S_SOFT", "R_ABORT"],
         currency=currency,
@@ -498,9 +498,9 @@ def test_send_payment_meets_travel_rule_threshold_sender_and_receiver_kyc_data_a
 
     send_payment_meets_travel_rule_threshold(
         sender=target_client.create_account(
-            balances={currency: travel_rule_threshold}, kyc_data=stub_client.new_kyc_data(sample="soft_match")
+            balances={currency: travel_rule_threshold}, kyc_data=stub_client.get_kyc_sample().soft_match
         ),
-        receiver=stub_client.create_account(kyc_data=target_client.new_kyc_data(sample="soft_match")),
+        receiver=stub_client.create_account(kyc_data=target_client.get_kyc_sample().soft_match),
         payment_command_states=["S_INIT", "R_SOFT", "S_SOFT_SEND", "R_SEND", "S_SOFT", "R_SOFT_SEND", "READY"],
         currency=currency,
         amount=travel_rule_threshold,
@@ -525,9 +525,9 @@ def test_send_payment_meets_travel_rule_threshold_sender_kyc_data_is_soft_match_
 
     send_payment_meets_travel_rule_threshold(
         sender=target_client.create_account(
-            balances={currency: travel_rule_threshold}, kyc_data=stub_client.new_kyc_data(sample="soft_match")
+            balances={currency: travel_rule_threshold}, kyc_data=stub_client.get_kyc_sample().soft_match
         ),
-        receiver=stub_client.create_account(kyc_data=target_client.new_kyc_data(sample="reject")),
+        receiver=stub_client.create_account(kyc_data=target_client.get_kyc_sample().reject),
         payment_command_states=["S_INIT", "R_SOFT", "S_SOFT_SEND", "R_SEND", "S_ABORT"],
         currency=currency,
         amount=travel_rule_threshold,
@@ -552,9 +552,9 @@ def test_send_payment_meets_travel_rule_threshold_sender_kyc_data_is_soft_match_
 
     send_payment_meets_travel_rule_threshold(
         sender=target_client.create_account(
-            balances={currency: travel_rule_threshold}, kyc_data=stub_client.new_kyc_data(sample="soft_match")
+            balances={currency: travel_rule_threshold}, kyc_data=stub_client.get_kyc_sample().soft_match
         ),
-        receiver=stub_client.create_account(kyc_data=target_client.new_kyc_data(sample="soft_reject")),
+        receiver=stub_client.create_account(kyc_data=target_client.get_kyc_sample().soft_reject),
         payment_command_states=["S_INIT", "R_SOFT", "S_SOFT_SEND", "R_SEND", "S_SOFT", "R_SOFT_SEND", "S_ABORT"],
         currency=currency,
         amount=travel_rule_threshold,

--- a/tests/miniwallet/test_api.py
+++ b/tests/miniwallet/test_api.py
@@ -8,7 +8,7 @@ import pytest, requests, json, time
 
 
 def test_create_account_with_balances_and_kyc_data(target_client: RestClient, currency: str) -> None:
-    kyc_data = target_client.new_kyc_data(sample="minimum")
+    kyc_data = target_client.get_kyc_sample().minimum
     balances = {currency: 123}
     account = target_client.create_account(balances, kyc_data=kyc_data)
     assert account.kyc_data == kyc_data
@@ -87,7 +87,7 @@ def test_account_balance_validation_should_exclude_canceled_transactions(
     amount = travel_rule_threshold
     receiver = target_client.create_account()
     payee = receiver.generate_account_identifier()
-    sender = stub_client.create_account({currency: amount}, kyc_data=target_client.new_kyc_data(sample="reject"))
+    sender = stub_client.create_account({currency: amount}, kyc_data=target_client.get_kyc_sample().reject)
     # payment should be rejected during offchain kyc data exchange
     payment = sender.send_payment(currency, amount, payee=payee)
 


### PR DESCRIPTION
1. inline stub and target account creation into test, so that the test code is easier for readers who are not familiar with pytest fixtures
2. remove mini-wallet client new_kyc_data, use get_kyc_sample instead; get_kyc_sample matches API endpoint kyc_sample and does nothing special inside.