### PR TITLE
add couple handy options to dmw cli

### DIFF
--- a/src/diem/testing/cli.py
+++ b/src/diem/testing/cli.py
@@ -11,6 +11,7 @@ from diem.testing.suites import envs
 from typing import Optional, TextIO
 import logging, click, functools, pytest, os, sys, json, shlex
 
+
 log_format: str = "%(name)s [%(asctime)s] %(levelname)s: %(message)s"
 click.option = functools.partial(click.option, show_default=True)  # pyre-ignore
 
@@ -25,13 +26,15 @@ def set_env(name: str, is_io: bool = False):  # pyre-ignore
 
 
 @click.group()
+@click.version_option(None, "-v", "--version")
+@click.help_option("-h", "--help")
 def main() -> None:
     pass
 
 
 @click.command()
 @click.option("--name", "-n", default="mini-wallet", help="Application name.")
-@click.option("--host", "-h", default="localhost", help="Start server host.")
+@click.option("--host", "-H", default="localhost", help="Start server host.")
 @click.option("--port", "-p", default=8888, help="Start server port.")
 @click.option("--jsonrpc", "-j", default=testnet.JSON_RPC_URL, help="Diem fullnode JSON-RPC URL.")
 @click.option("--faucet", "-f", default=testnet.FAUCET_URL, help="Testnet faucet URL.")
@@ -46,6 +49,7 @@ def main() -> None:
     help="Import the diem account config from a file. The config file content should be JSON generated from command `gen-diem-account-config`.",
     type=click.File(),
 )
+@click.help_option("-h", "--help")
 def start_server(
     name: str,
     host: str,
@@ -81,7 +85,7 @@ def start_server(
 )
 @click.option(
     "--stub-bind-host",
-    "-h",
+    "-H",
     default="localhost",
     callback=set_env(envs.DMW_STUB_BIND_HOST),
     help="The host the miniwallet stub server will bind to",
@@ -127,6 +131,7 @@ def start_server(
     help="Import the diem account config from a file for miniwallet stub server. The config file content should be JSON generated from command `gen-diem-account-config`.",
     type=click.File(),
 )
+@click.help_option("-h", "--help")
 def test(
     target: str,
     stub_bind_host: Optional[str],
@@ -164,6 +169,7 @@ def test(
 
 
 @click.command()
+@click.help_option("-h", "--help")
 def gen_diem_account_config() -> None:
     print(LocalAccount().to_json())
 

--- a/src/diem/testing/cli.py
+++ b/src/diem/testing/cli.py
@@ -102,6 +102,12 @@ def start_server(
     help="The address that will be used for offchain callbacks. Defaults to http://localhost:{random_port}",
 )
 @click.option("--jsonrpc", "-j", default=testnet.JSON_RPC_URL, help="Diem fullnode JSON-RPC URL.")
+@click.option(
+    "--match-keywords",
+    "-k",
+    default=None,
+    help="Only run tests which match the given substring expression. Same with pytest `-k` option. Example: -k 'test_method or test_other' matches all test functions and classes whose name contains 'test_method' or 'test_other', while -k 'not test_method' matches those that don't contain 'test_method' in their names",
+)
 @click.option("--faucet", "-f", default=testnet.FAUCET_URL, help="Testnet faucet URL.")
 @click.option(
     "--pytest-args",
@@ -127,6 +133,7 @@ def test(
     stub_bind_port: Optional[int],
     stub_diem_account_base_url: Optional[str],
     jsonrpc: str,
+    match_keywords: str,
     faucet: str,
     pytest_args: str,
     logfile: Optional[str],
@@ -141,6 +148,9 @@ def test(
 
     args = shlex.split(pytest_args)
     args = ["--pyargs", "diem.testing.suites"] + args
+    if match_keywords:
+        args.append("-k")
+        args.append(match_keywords)
     if verbose:
         args.append("--log-level=INFO")
         args.append("-s")

--- a/tests/test_testing_cli.py
+++ b/tests/test_testing_cli.py
@@ -35,9 +35,29 @@ def test_gen_diem_account_config(runner: CliRunner) -> None:
     assert default == account
 
 
-def test_start_server_and_run_one_test(runner: CliRunner) -> None:
+def test_start_server_and_run_test_with_matching_keywords(runner: CliRunner) -> None:
     conf = start_target_server(runner)
-    result = start_test(runner, conf)
+    result = start_test(
+        runner,
+        conf,
+        [
+            "-k",
+            "test_invalid_jws_message_signature or test_receive_payment_with_general_metadata_and_valid_from_and_to_subaddresses",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+
+def test_run_test_with_pytest_args(runner: CliRunner) -> None:
+    conf = start_target_server(runner)
+    result = start_test(
+        runner,
+        conf,
+        [
+            "--pytest-args",
+            "-k 'test_invalid_jws_message_signature or test_receive_payment_with_general_metadata_and_valid_from_and_to_subaddresses'",
+        ],
+    )
     assert result.exit_code == 0, result.output
 
 
@@ -49,7 +69,16 @@ def test_load_diem_account_config_file(runner: CliRunner) -> None:
         LocalAccount(hrp=identifier.DM).write_to_file(stub_config_file)
 
         conf = start_target_server(runner, ["-i", app_config_file])
-        result = start_test(runner, conf, ["-i", stub_config_file])
+        result = start_test(
+            runner,
+            conf,
+            [
+                "-i",
+                stub_config_file,
+                "-k",
+                "test_receive_payment_with_general_metadata_and_valid_from_and_to_subaddresses",
+            ],
+        )
 
         assert result.exit_code == 0, result.output
 
@@ -65,8 +94,6 @@ def start_test(runner: CliRunner, conf: ServerConfig, options: List[str] = []) -
             testnet.JSON_RPC_URL,
             "--faucet",
             testnet.FAUCET_URL,
-            "--pytest-args",
-            "-k 'test_receive_payment_with_general_metadata_and_valid_from_and_to_subaddresses or test_invalid_jws_message_signature'",
             "--stub-bind-host",
             "0.0.0.0",
             "--stub-bind-port",

--- a/tests/test_testing_cli.py
+++ b/tests/test_testing_cli.py
@@ -8,7 +8,7 @@ from diem.testing.miniwallet import ServerConfig
 from diem.testing import LocalAccount
 from diem import identifier, testnet, utils
 from typing import List
-import json, threading, pytest
+import json, threading, pytest, pkg_resources
 
 
 @pytest.fixture(autouse=True)
@@ -19,6 +19,22 @@ def disable_self_check(monkeypatch) -> None:
 @pytest.fixture()
 def runner() -> CliRunner:
     return CliRunner()
+
+
+def test_version(runner: CliRunner) -> None:
+    version = pkg_resources.require("diem")[0].version
+
+    for version_opt in ["-v", "--version"]:
+        result = runner.invoke(cli.main, [version_opt])
+        assert result.exit_code == 0
+        assert ("version %s" % version) in result.output
+
+
+def test_help_shortcut(runner: CliRunner) -> None:
+    for fn in [cli.main, cli.start_server, cli.test, cli.gen_diem_account_config]:
+        result = runner.invoke(fn, ["-h"])
+        assert result.exit_code == 0
+        assert ("-h, --help") in result.output
 
 
 def test_gen_diem_account_config(runner: CliRunner) -> None:


### PR DESCRIPTION
1. add `-k` option to dmw test command for running tests with matching keywords
2. add version option to dmw cli
3. add `-h` option as help option shortcut; changed `--host` and `--stub-bind-host` shortcut to `-H`