### PR TITLE
disable account background tasks for test

### DIFF
--- a/src/diem/testing/miniwallet/app/__init__.py
+++ b/src/diem/testing/miniwallet/app/__init__.py
@@ -4,3 +4,4 @@
 from .app import App
 from .models import Account, Transaction, Event, KycSample, PaymentCommand, RefundReason, Subaddress
 from .api import falcon_api
+from .pending_account import PENDING_INBOUND_ACCOUNT_ID

--- a/src/diem/testing/miniwallet/app/models.py
+++ b/src/diem/testing/miniwallet/app/models.py
@@ -17,6 +17,7 @@ class Base:
 class Account(Base):
     kyc_data: Optional[offchain.KycDataObject] = field(default=None)
     reject_additional_kyc_data_request: Optional[bool] = field(default=False)
+    disable_background_tasks: Optional[bool] = field(default=False)
 
     def kyc_data_object(self) -> offchain.KycDataObject:
         return self.kyc_data if self.kyc_data else offchain.individual_kyc_data()  # pyre-ignore

--- a/src/diem/testing/miniwallet/app/pending_account.py
+++ b/src/diem/testing/miniwallet/app/pending_account.py
@@ -1,0 +1,5 @@
+# Copyright (c) The Diem Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+
+PENDING_INBOUND_ACCOUNT_ID: str = "pending_inbound_account"

--- a/src/diem/testing/miniwallet/app/store.py
+++ b/src/diem/testing/miniwallet/app/store.py
@@ -74,7 +74,8 @@ class InMemoryStore:
         records[index] = asdict(obj)
 
     def _insert(self, typ: Type[T], **res: Any) -> Dict[str, Any]:
-        res["id"] = str(self.next_id())
+        if "id" not in res:
+            res["id"] = str(self.next_id())
         self.resources.setdefault(typ, []).append(asdict(typ(**res)))
         return res
 

--- a/src/diem/testing/miniwallet/client.py
+++ b/src/diem/testing/miniwallet/client.py
@@ -39,11 +39,13 @@ class RestClient:
         balances: Optional[Dict[str, int]] = None,
         kyc_data: Optional[offchain.KycDataObject] = None,
         reject_additional_kyc_data_request: Optional[bool] = None,
+        disable_background_tasks: Optional[bool] = None,
     ) -> "AccountResource":
         kwargs = {
             "balances": balances,
             "kyc_data": asdict(kyc_data) if kyc_data else None,
             "reject_additional_kyc_data_request": reject_additional_kyc_data_request,
+            "disable_background_tasks": disable_background_tasks,
         }
         account = self.create("/accounts", **{k: v for k, v in kwargs.items() if v})
         return AccountResource(client=self, id=account["id"], kyc_data=kyc_data)

--- a/src/diem/testing/suites/conftest.py
+++ b/src/diem/testing/suites/conftest.py
@@ -5,7 +5,7 @@
 from ... import testnet, jsonrpc, identifier, offchain
 from .. import LocalAccount
 from ..miniwallet import RestClient, AppConfig, AccountResource, ServerConfig, App
-from ..miniwallet.app.event_puller import PENDING_INBOUND_ACCOUNT_ID
+from ..miniwallet.app import PENDING_INBOUND_ACCOUNT_ID
 from .envs import (
     target_url,
     is_self_check,
@@ -15,7 +15,6 @@ from .envs import (
 )
 from typing import Optional, Tuple, Dict, Any, Generator
 from dataclasses import asdict
-from contextlib import contextmanager
 import pytest, json, uuid, requests, time, warnings
 
 
@@ -112,18 +111,6 @@ def log_stub_wallet_pending_income_account(
 ) -> Generator[None, None, None]:
     yield
     stub_wallet_pending_income_account.log_events()
-
-
-@contextmanager
-def disable_background_tasks(app: App) -> Generator[None, None, None]:
-    app.bg_worker = "disable"
-    # wait for status changed from disable to disabled
-    while app.bg_worker == "disable":
-        time.sleep(0.01)
-    try:
-        yield
-    finally:
-        app.bg_worker = "running"
 
 
 def send_request_json(

--- a/src/diem/testing/suites/test_payment_command.py
+++ b/src/diem/testing/suites/test_payment_command.py
@@ -10,7 +10,6 @@ from .conftest import (
     assert_response_error,
     payment_command_request_sample,
     send_request_json,
-    disable_background_tasks,
 )
 import json, pytest
 
@@ -278,19 +277,20 @@ def test_replay_the_same_payment_command(
     """
 
     sender_account = stub_client.create_account(
-        balances={currency: travel_rule_threshold}, kyc_data=target_client.get_kyc_sample().minimum
+        balances={currency: travel_rule_threshold},
+        kyc_data=target_client.get_kyc_sample().minimum,
+        disable_background_tasks=True,
     )
     receiver_account = target_client.create_account(kyc_data=stub_client.get_kyc_sample().minimum)
     try:
         payee = receiver_account.generate_account_identifier()
 
-        with disable_background_tasks(stub_wallet_app):
-            payment = sender_account.send_payment(currency=currency, amount=travel_rule_threshold, payee=payee)
-            txn = stub_wallet_app.store.find(Transaction, id=payment.id)
-            # send initial payment command
-            cmd = stub_wallet_app.send_initial_payment_command(txn)
-            stub_wallet_app.send_offchain_command_without_retries(cmd)
-            stub_wallet_app.send_offchain_command_without_retries(cmd)
+        payment = sender_account.send_payment(currency=currency, amount=travel_rule_threshold, payee=payee)
+        txn = stub_wallet_app.store.find(Transaction, id=payment.id)
+        # send initial payment command
+        cmd = stub_wallet_app.send_initial_payment_command(txn)
+        stub_wallet_app.send_offchain_command_without_retries(cmd)
+        stub_wallet_app.send_offchain_command_without_retries(cmd)
     finally:
         receiver_account.log_events()
         sender_account.log_events()
@@ -319,37 +319,38 @@ def test_payment_command_sender_kyc_data_can_only_be_written_once(
     """
 
     sender_account = stub_client.create_account(
-        balances={currency: travel_rule_threshold}, kyc_data=target_client.get_kyc_sample().minimum
+        balances={currency: travel_rule_threshold},
+        kyc_data=target_client.get_kyc_sample().minimum,
+        disable_background_tasks=True,
     )
     receiver_account = target_client.create_account(kyc_data=stub_client.get_kyc_sample().minimum)
     try:
         payee = receiver_account.generate_account_identifier()
 
-        with disable_background_tasks(stub_wallet_app):
-            payment = sender_account.send_payment(currency=currency, amount=travel_rule_threshold, payee=payee)
-            txn = stub_wallet_app.store.find(Transaction, id=payment.id)
-            # send initial payment command
-            initial_cmd = stub_wallet_app.send_initial_payment_command(txn)
+        payment = sender_account.send_payment(currency=currency, amount=travel_rule_threshold, payee=payee)
+        txn = stub_wallet_app.store.find(Transaction, id=payment.id)
+        # send initial payment command
+        initial_cmd = stub_wallet_app.send_initial_payment_command(txn)
 
-            # wait for receiver to update payment command
-            sender_account.wait_for_event("updated_payment_command")
-            # find updated payment command
-            updated_cmd = stub_wallet_app.store.find(PaymentCommand, reference_id=initial_cmd.reference_id())
-            offchain_cmd = updated_cmd.to_offchain_command()
+        # wait for receiver to update payment command
+        sender_account.wait_for_event("updated_payment_command")
+        # find updated payment command
+        updated_cmd = stub_wallet_app.store.find(PaymentCommand, reference_id=initial_cmd.reference_id())
+        offchain_cmd = updated_cmd.to_offchain_command()
 
-            # update sender KYC data
-            assert offchain_cmd.payment.sender.kyc_data
-            if offchain_cmd.payment.sender.kyc_data.dob == "01/01/1979":
-                kyc_data = replace(offchain_cmd.payment.sender.kyc_data, dob="01/01/1979")
-            else:
-                kyc_data = replace(offchain_cmd.payment.sender.kyc_data, dob="01/02/1979")
-            # create new payment command with correct status and changed kyc data
-            new_cmd = offchain_cmd.new_command(status=offchain.Status.ready_for_settlement, kyc_data=kyc_data)
+        # update sender KYC data
+        assert offchain_cmd.payment.sender.kyc_data
+        if offchain_cmd.payment.sender.kyc_data.dob == "01/01/1979":
+            kyc_data = replace(offchain_cmd.payment.sender.kyc_data, dob="01/01/1979")
+        else:
+            kyc_data = replace(offchain_cmd.payment.sender.kyc_data, dob="01/02/1979")
+        # create new payment command with correct status and changed kyc data
+        new_cmd = offchain_cmd.new_command(status=offchain.Status.ready_for_settlement, kyc_data=kyc_data)
 
-            with pytest.raises(offchain.CommandResponseError) as err:
-                stub_wallet_app.send_offchain_command_without_retries(new_cmd)
+        with pytest.raises(offchain.CommandResponseError) as err:
+            stub_wallet_app.send_offchain_command_without_retries(new_cmd)
 
-            assert_response_error(err.value.resp, "invalid_overwrite", "command_error", field="payment.sender.kyc_data")
+        assert_response_error(err.value.resp, "invalid_overwrite", "command_error", field="payment.sender.kyc_data")
     finally:
         receiver_account.log_events()
         sender_account.log_events()
@@ -379,38 +380,39 @@ def test_payment_command_sender_address_can_only_be_written_once(
     """
 
     sender_account = stub_client.create_account(
-        balances={currency: travel_rule_threshold}, kyc_data=target_client.get_kyc_sample().minimum
+        balances={currency: travel_rule_threshold},
+        kyc_data=target_client.get_kyc_sample().minimum,
+        disable_background_tasks=True,
     )
     receiver_account = target_client.create_account(kyc_data=stub_client.get_kyc_sample().minimum)
     try:
         payee = receiver_account.generate_account_identifier()
 
-        with disable_background_tasks(stub_wallet_app):
-            payment = sender_account.send_payment(currency=currency, amount=travel_rule_threshold, payee=payee)
-            txn = stub_wallet_app.store.find(Transaction, id=payment.id)
-            # send initial payment command
-            initial_cmd = stub_wallet_app.send_initial_payment_command(txn)
+        payment = sender_account.send_payment(currency=currency, amount=travel_rule_threshold, payee=payee)
+        txn = stub_wallet_app.store.find(Transaction, id=payment.id)
+        # send initial payment command
+        initial_cmd = stub_wallet_app.send_initial_payment_command(txn)
 
-            # wait for receiver to update payment command
-            sender_account.wait_for_event("updated_payment_command")
-            # find updated payment command
-            updated_cmd = stub_wallet_app.store.find(PaymentCommand, reference_id=initial_cmd.reference_id())
-            offchain_cmd = updated_cmd.to_offchain_command()
+        # wait for receiver to update payment command
+        sender_account.wait_for_event("updated_payment_command")
+        # find updated payment command
+        updated_cmd = stub_wallet_app.store.find(PaymentCommand, reference_id=initial_cmd.reference_id())
+        offchain_cmd = updated_cmd.to_offchain_command()
 
-            # update sender address
-            sender_account_address = offchain_cmd.sender_account_address(hrp)
-            new_subaddress = stub_wallet_app._gen_subaddress(sender_account.id)
-            new_sender_address = identifier.encode_account(sender_account_address, new_subaddress, hrp)
-            new_sender = replace(offchain_cmd.payment.sender, address=new_sender_address)
-            new_payment = replace(offchain_cmd.payment, sender=new_sender)
-            new_offchain_cmd = replace(offchain_cmd, payment=new_payment, my_actor_address=new_sender_address)
+        # update sender address
+        sender_account_address = offchain_cmd.sender_account_address(hrp)
+        new_subaddress = stub_wallet_app._gen_subaddress(sender_account.id)
+        new_sender_address = identifier.encode_account(sender_account_address, new_subaddress, hrp)
+        new_sender = replace(offchain_cmd.payment.sender, address=new_sender_address)
+        new_payment = replace(offchain_cmd.payment, sender=new_sender)
+        new_offchain_cmd = replace(offchain_cmd, payment=new_payment, my_actor_address=new_sender_address)
 
-            new_cmd = new_offchain_cmd.new_command(status=offchain.Status.ready_for_settlement)
+        new_cmd = new_offchain_cmd.new_command(status=offchain.Status.ready_for_settlement)
 
-            with pytest.raises(offchain.CommandResponseError) as err:
-                stub_wallet_app.send_offchain_command_without_retries(new_cmd)
+        with pytest.raises(offchain.CommandResponseError) as err:
+            stub_wallet_app.send_offchain_command_without_retries(new_cmd)
 
-            assert_response_error(err.value.resp, "invalid_overwrite", "command_error", field="payment.sender.address")
+        assert_response_error(err.value.resp, "invalid_overwrite", "command_error", field="payment.sender.address")
     finally:
         receiver_account.log_events()
         sender_account.log_events()
@@ -449,41 +451,42 @@ def test_payment_command_action_can_only_be_written_once(
     """
 
     sender_account = stub_client.create_account(
-        balances={currency: travel_rule_threshold}, kyc_data=target_client.get_kyc_sample().minimum
+        balances={currency: travel_rule_threshold},
+        kyc_data=target_client.get_kyc_sample().minimum,
+        disable_background_tasks=True,
     )
     receiver_account = target_client.create_account(kyc_data=stub_client.get_kyc_sample().minimum)
     try:
         payee = receiver_account.generate_account_identifier()
 
-        with disable_background_tasks(stub_wallet_app):
-            payment = sender_account.send_payment(currency=currency, amount=travel_rule_threshold, payee=payee)
-            txn = stub_wallet_app.store.find(Transaction, id=payment.id)
-            # send initial payment command
-            initial_cmd = stub_wallet_app.send_initial_payment_command(txn)
+        payment = sender_account.send_payment(currency=currency, amount=travel_rule_threshold, payee=payee)
+        txn = stub_wallet_app.store.find(Transaction, id=payment.id)
+        # send initial payment command
+        initial_cmd = stub_wallet_app.send_initial_payment_command(txn)
 
-            # wait for receiver to update payment command
-            sender_account.wait_for_event("updated_payment_command")
-            # find updated payment command
-            updated_cmd = stub_wallet_app.store.find(PaymentCommand, reference_id=initial_cmd.reference_id())
-            offchain_cmd = updated_cmd.to_offchain_command()
+        # wait for receiver to update payment command
+        sender_account.wait_for_event("updated_payment_command")
+        # find updated payment command
+        updated_cmd = stub_wallet_app.store.find(PaymentCommand, reference_id=initial_cmd.reference_id())
+        offchain_cmd = updated_cmd.to_offchain_command()
 
-            # update action field value
-            if field_name == "currency":
-                field_value = "XDX" if offchain_cmd.payment.action.currency == "XUS" else "XUS"
-            elif field_name == "amount":
-                field_value = offchain_cmd.payment.action.amount + 10_000
-            elif field_name == "timestamp":
-                field_value = offchain_cmd.payment.action.timestamp - 1
-            new_action = replace(offchain_cmd.payment.action, **{field_name: field_value})
-            new_payment = replace(offchain_cmd.payment, action=new_action)
-            new_offchain_cmd = replace(offchain_cmd, payment=new_payment)
+        # update action field value
+        if field_name == "currency":
+            field_value = "XDX" if offchain_cmd.payment.action.currency == "XUS" else "XUS"
+        elif field_name == "amount":
+            field_value = offchain_cmd.payment.action.amount + 10_000
+        elif field_name == "timestamp":
+            field_value = offchain_cmd.payment.action.timestamp - 1
+        new_action = replace(offchain_cmd.payment.action, **{field_name: field_value})
+        new_payment = replace(offchain_cmd.payment, action=new_action)
+        new_offchain_cmd = replace(offchain_cmd, payment=new_payment)
 
-            new_cmd = new_offchain_cmd.new_command(status=offchain.Status.ready_for_settlement)
+        new_cmd = new_offchain_cmd.new_command(status=offchain.Status.ready_for_settlement)
 
-            with pytest.raises(offchain.CommandResponseError) as err:
-                stub_wallet_app.send_offchain_command_without_retries(new_cmd)
+        with pytest.raises(offchain.CommandResponseError) as err:
+            stub_wallet_app.send_offchain_command_without_retries(new_cmd)
 
-            assert_response_error(err.value.resp, "invalid_overwrite", "command_error", field="payment.action")
+        assert_response_error(err.value.resp, "invalid_overwrite", "command_error", field="payment.action")
     finally:
         receiver_account.log_events()
         sender_account.log_events()

--- a/tests/miniwallet/test_store.py
+++ b/tests/miniwallet/test_store.py
@@ -18,6 +18,12 @@ def test_create_event():
     assert s.find_all(Event) == [event]
 
 
+def test_create_with_id():
+    s = store.InMemoryStore()
+    account = s.create(Account, id="abc")
+    assert account.id == "abc"
+
+
 def test_find_returns_one_matched_item():
     s = store.InMemoryStore()
     s.create_event("1", "create-abc", "test data")


### PR DESCRIPTION
As we use account as data isolation in the test, it is better to just disable one account's background tasks.