### PR TITLE
add a wait for target wallet application ready to dmw test command

### DIFF
--- a/src/diem/testnet.py
+++ b/src/diem/testnet.py
@@ -28,8 +28,8 @@ from . import diem_types, jsonrpc, utils, chain_ids, bcs, identifier
 from .testing import LocalAccount
 
 
-JSON_RPC_URL: str = "http://testnet.diem.com/v1"
-FAUCET_URL: str = "http://testnet.diem.com/mint"
+JSON_RPC_URL: str = "https://testnet.diem.com/v1"
+FAUCET_URL: str = "https://testnet.diem.com/mint"
 CHAIN_ID: diem_types.ChainId = chain_ids.TESTNET
 
 DESIGNATED_DEALER_ADDRESS: diem_types.AccountAddress = utils.account_address("000000000000000000000000000000dd")

--- a/tests/test_testing_cli.py
+++ b/tests/test_testing_cli.py
@@ -8,7 +8,7 @@ from diem.testing.miniwallet import ServerConfig, RestClient
 from diem.testing import LocalAccount
 from diem import identifier, testnet, utils
 from typing import List
-import json, threading, pytest, pkg_resources
+import json, threading, pytest, pkg_resources, time
 
 
 @pytest.fixture(autouse=True)
@@ -142,6 +142,23 @@ def test_hrp_option_overwrites_hrp_from_diem_account_config_file(runner: CliRunn
         )
 
         assert result.exit_code == 0, result.output
+
+
+def test_wait_timeout_for_target_ready(runner: CliRunner) -> None:
+    start = time.time()
+    result = start_test(
+        runner,
+        ServerConfig(),
+        [
+            "--wait-for-target-timeout",
+            1,
+            "-k",
+            "test_create_a_blank_account",
+        ],
+    )
+    assert result.exit_code == 1, result.output
+    duration = time.time() - start
+    assert duration < 2
 
 
 def start_test(runner: CliRunner, conf: ServerConfig, options: List[str] = []) -> Result:


### PR DESCRIPTION
This is useful when launching target wallet application inside a docker container, which requires a wait for the server ready.
Current dmw test does some wait by retrying when first call to target wallet application, but the error output is huge and confusing, thus a specific wait can make it easier to understand what's going on for user.