### PR TITLE
enforce account setup when startup the app

### DIFF
--- a/src/diem/__VERSION__.py
+++ b/src/diem/__VERSION__.py
@@ -1,4 +1,4 @@
 # Copyright (c) The Diem Core Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-VERSION = "1.6.1"
+VERSION = "1.6.2"

--- a/src/diem/testing/miniwallet/client.py
+++ b/src/diem/testing/miniwallet/client.py
@@ -173,7 +173,7 @@ class AccountResource:
 
         self.wait_for(fn)
 
-    def wait_for(self, fn: Callable[[], None], max_tries: int = 120, delay: float = 0.1) -> None:
+    def wait_for(self, fn: Callable[[], None], max_tries: int = 60, delay: float = 0.1) -> None:
         """Wait for a fucntion call success
 
         The given `fn` argument should:

--- a/src/diem/testing/miniwallet/config.py
+++ b/src/diem/testing/miniwallet/config.py
@@ -53,21 +53,20 @@ class AppConfig:
         return RestClient(server_url=self.server_url, name="%s-client" % self.name).with_retry()
 
     def setup_account(self, client: jsonrpc.Client) -> None:
-        if not client.get_account(self.account.account_address):
-            self.logger.info("faucet: mint %s", self.account.account_address.to_hex())
-            faucet = testnet.Faucet(client)
-            faucet.mint(self.account.auth_key.hex(), self.initial_amount, self.initial_currency)
+        self.logger.info("faucet: mint %s", self.account.account_address.to_hex())
+        faucet = testnet.Faucet(client)
+        faucet.mint(self.account.auth_key.hex(), self.initial_amount, self.initial_currency)
 
-            self.logger.info("rotate dual attestation info for %s", self.account.account_address.to_hex())
-            self.logger.info("set base url to: %s", self.server_url)
-            self.account.rotate_dual_attestation_info(client, self.server_url)
+        self.logger.info("rotate dual attestation info for %s", self.account.account_address.to_hex())
+        self.logger.info("set base url to: %s", self.server_url)
+        self.account.rotate_dual_attestation_info(client, self.server_url)
 
-            self.logger.info("generate child VASP accounts: %s", self.child_account_size)
-            child_account_initial_amount = int(self.initial_amount / (self.child_account_size + 1))
-            for i in range(self.child_account_size):
-                child = self.account.gen_child_vasp(client, child_account_initial_amount, self.initial_currency)
-                self.logger.info("generate child VASP account(%s): %s", i, child.to_dict())
-                self.child_account_configs.append(child.to_dict())
+        self.logger.info("generate child VASP accounts: %s", self.child_account_size)
+        child_account_initial_amount = int(self.initial_amount / (self.child_account_size + 1))
+        for i in range(self.child_account_size):
+            child = self.account.gen_child_vasp(client, child_account_initial_amount, self.initial_currency)
+            self.logger.info("generate child VASP account(%s): %s", i, child.to_dict())
+            self.child_account_configs.append(child.to_dict())
 
     def serve(self, client: jsonrpc.Client, app: App) -> threading.Thread:
         api: falcon.API = falcon_api(app, self.disable_events_api)

--- a/tests/test_testing_cli.py
+++ b/tests/test_testing_cli.py
@@ -98,6 +98,20 @@ def test_load_diem_account_config_file(runner: CliRunner) -> None:
 
         assert result.exit_code == 0, result.output
 
+        # use the same configuration file for multiple times testing
+        result = start_test(
+            runner,
+            conf,
+            [
+                "-i",
+                stub_config_file,
+                "-k",
+                "test_receive_payment_meets_travel_rule_threshold_both_kyc_data_evaluations_are_accepted",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+
 
 def test_hrp_option(runner: CliRunner) -> None:
     conf = start_target_server(runner, ["--hrp", "xdm"])


### PR DESCRIPTION
Avoid reusing account configuration for running tests multiple times.