### PR TITLE
miniwallet app: ensure account balance is always enough for payment

### DIFF
--- a/tests/miniwallet/test_diem_account.py
+++ b/tests/miniwallet/test_diem_account.py
@@ -14,9 +14,10 @@ def test_no_child_accounts():
     account = testnet.gen_account(client)
     da = DiemAccount(account, [], client)
     assert da.hrp == account.hrp
-    assert da.account_identifier(None) == account.account_identifier(None)
+    assert da.account_identifier() == account.account_identifier()
 
-    signed_txn_hex = da.submit_p2p(gen_txn(), (b"", b""))
+    payee = testnet.gen_account(client)
+    signed_txn_hex = da.submit_p2p(gen_txn(payee=payee.account_identifier()), (b"", b""))
     signed_txn = diem_types.SignedTransaction.bcs_deserialize(bytes.fromhex(signed_txn_hex))
     assert signed_txn.raw_txn.sender == account.account_address
 
@@ -26,16 +27,29 @@ def test_submit_p2p_with_unknown_address():
     account = testnet.gen_account(client)
     da = DiemAccount(account, [], client)
     with pytest.raises(ValueError):
-        da.submit_p2p(gen_txn(), (b"", b""), by_address=LocalAccount().account_address)
+        payee = LocalAccount().account_identifier()
+        da.submit_p2p(gen_txn(payee=payee), (b"", b""), by_address=LocalAccount().account_address)
 
 
-def gen_txn() -> Transaction:
+def test_ensure_account_balance_is_always_enough():
+    client = testnet.create_client()
+    account = LocalAccount.generate()
+    testnet.Faucet(client).mint(account.auth_key.hex(), 1, testnet.TEST_CURRENCY_CODE)
+    da = DiemAccount(account, [], client)
+    account_data = client.must_get_account(account.account_address)
+    amount = account_data.balances[0].amount + 1
+    payee = testnet.gen_account(client)
+    txn = da.submit_p2p(gen_txn(payee=payee.account_identifier(), amount=amount), (b"", b""))
+    client.wait_for_transaction(txn)
+
+
+def gen_txn(payee: str, amount: int = 1) -> Transaction:
     return Transaction(
         id="txn",
         account_id="id",
         currency="XUS",
-        amount=1,
+        amount=amount,
         status=Transaction.Status.pending,
         type=Transaction.Type.sent_payment,
-        payee=LocalAccount().account_identifier(None),
+        payee=payee,
     )


### PR DESCRIPTION
When sending out payment, instead of raising errors, we auto refill the account by faucet, so that the usage of mini-wallet application has better user experience as a testing wallet application.