### PR TITLE
reduce log noise for running test suites

### DIFF
--- a/src/diem/testing/miniwallet/app/api.py
+++ b/src/diem/testing/miniwallet/app/api.py
@@ -21,7 +21,8 @@ class LoggerMiddleware:
 
     def process_response(self, req, resp, *args, **kwargs):  # pyre-ignore
         tc = req.get_header("X-Test-Case")
-        test_case = "[%s] " % tc if tc else ""
+        # test case format is <file>::<test method name>, only log the test method name
+        test_case = "[%s] " % tc.split("::")[-1] if tc else ""
         self.logger.info("%s%s %s - %s", test_case, req.method, req.relative_uri, resp.status)
 
 

--- a/src/diem/testing/miniwallet/client.py
+++ b/src/diem/testing/miniwallet/client.py
@@ -26,6 +26,7 @@ class RestClient:
     server_url: str
     session: requests.Session = field(default_factory=requests.Session)
     logger: logging.Logger = field(init=False)
+    events_api_is_optional: bool = field(default=False)
 
     def __post_init__(self) -> None:
         self.logger = logging.getLogger(self.name)
@@ -74,6 +75,9 @@ class RestClient:
             headers={k: v for k, v in headers.items() if v},
         )
         log_level = logging.DEBUG if resp.status_code < 300 else logging.ERROR
+        if self.events_api_is_optional and path.endswith("/events"):
+            log_level = logging.DEBUG
+
         self.logger.log(log_level, "%s %s: %s - %s", method, path, data, resp.status_code)
         self.logger.log(log_level, "response body: \n%s", try_json(resp.text))
         resp.raise_for_status()

--- a/src/diem/testing/suites/conftest.py
+++ b/src/diem/testing/suites/conftest.py
@@ -26,7 +26,7 @@ def target_client(diem_client: jsonrpc.Client) -> RestClient:
         conf.start(diem_client)
         return conf.create_client()
     print("target wallet server url: %s" % target_url())
-    return RestClient(name="target-wallet-client", server_url=target_url()).with_retry()
+    return RestClient(name="target-wallet-client", server_url=target_url(), events_api_is_optional=True).with_retry()
 
 
 @pytest.fixture(scope="package")


### PR DESCRIPTION
1. change log level to debug when called events api failed on the target wallet application, because the api is optional, when it is not implemented, logging an error causes confusion, thus logging a debug message is better.
2. when logging x-test-case header, only log test name, which should be good enough.