### PR TITLE
improve assertion failure output by test suites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ format:
 test: format runtest
 
 runtest:
-	DMW_SELF_CHECK=Y ./venv/bin/pytest src/diem/testing/suites tests examples --log-level info -k "$(t)" $(args)
+	DMW_SELF_CHECK=Y ./venv/bin/pytest src/diem/testing/suites tests examples -k "$(t)" $(args)
 
 profile:
 	./venv/bin/python -m profile -m pytest tests examples -k "$(t)" $(args)

--- a/src/diem/testing/suites/test_payment_command.py
+++ b/src/diem/testing/suites/test_payment_command.py
@@ -10,6 +10,7 @@ from .conftest import (
     assert_response_error,
     payment_command_request_sample,
     send_request_json,
+    wait_for_event,
 )
 import json, pytest
 
@@ -333,7 +334,7 @@ def test_payment_command_sender_kyc_data_can_only_be_written_once(
         initial_cmd = stub_wallet_app.send_initial_payment_command(txn)
 
         # wait for receiver to update payment command
-        sender_account.wait_for_event("updated_payment_command")
+        wait_for_event(sender_account, "updated_payment_command")
         # find updated payment command
         updated_cmd = stub_wallet_app.store.find(PaymentCommand, reference_id=initial_cmd.reference_id())
         offchain_cmd = updated_cmd.to_offchain_command()
@@ -394,7 +395,7 @@ def test_payment_command_sender_address_can_only_be_written_once(
         initial_cmd = stub_wallet_app.send_initial_payment_command(txn)
 
         # wait for receiver to update payment command
-        sender_account.wait_for_event("updated_payment_command")
+        wait_for_event(sender_account, "updated_payment_command")
         # find updated payment command
         updated_cmd = stub_wallet_app.store.find(PaymentCommand, reference_id=initial_cmd.reference_id())
         offchain_cmd = updated_cmd.to_offchain_command()
@@ -465,7 +466,7 @@ def test_payment_command_action_can_only_be_written_once(
         initial_cmd = stub_wallet_app.send_initial_payment_command(txn)
 
         # wait for receiver to update payment command
-        sender_account.wait_for_event("updated_payment_command")
+        wait_for_event(sender_account, "updated_payment_command")
         # find updated payment command
         updated_cmd = stub_wallet_app.store.find(PaymentCommand, reference_id=initial_cmd.reference_id())
         offchain_cmd = updated_cmd.to_offchain_command()


### PR DESCRIPTION
Removed "--log-level info " in test target, make the test failure output more close to `dmw test` default output; and we should make the assertion error more readable for easier to understand what's going wrong.

When the assertion code is in testing directory, the pytest error message will output something like this:

```
    def match_balance() -> None:
>       assert account.balance(currency) == amount
E       AssertionError: assert 10000 == 10001
E        +  where 10000 = <bound method AccountResource.balance of AccountResource(client=RestClient(name='stub-wallet-client', server_url='http...equests.sessions.Session object at 0x110c99760>, logger=<Logger stub-wallet-client (WARNING)>), id='2', kyc_data=None)>('XUS')
E        +    where <bound method AccountResource.balance of AccountResource(client=RestClient(name='stub-wallet-client', server_url='http...equests.sessions.Session object at 0x110c99760>, logger=<Logger stub-wallet-client (WARNING)>), id='2', kyc_data=None)> = AccountResource(client=RestClient(name='stub-wallet-client', server_url='http://localhost:54078', session=<requests.sessions.Session object at 0x110c99760>, logger=<Logger stub-wallet-client (WARNING)>), id='2', kyc_data=None).balance

src/diem/testing/suites/conftest.py:231: AssertionError
```

It is better than current assertion error message when the assertion code is inside AccountResource class (not in testing directory):

```
    def fn() -> None:
>       assert self.balance(currency) == amount
E       AssertionError

src/diem/testing/miniwallet/client.py:147: AssertionError
```

Hence we moved all wait for condition util methods from AccountResource into conftest.py under the suites package for sharing in test files.

Another change related is: removed TimeoutError in `wait_for` function, direct re-raise the assertion error instead. 
Because it is cleaner result by direct re-raise assertion error. 
Raising TimeoutError from the assertion error will print a lot of information related to the TimeoutError at the end, but it is better to first read the assertion error for understanding what is wrong.