### PR TITLE
diem async jsonrpc client and faucet client

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -10,6 +10,9 @@ def setup_testnet() -> None:
     if os.getenv("dt"):
         os.system("make docker")
         print("swap testnet default values to local testnet launched by docker-compose")
+        os.environ["DIEM_JSON_RPC_URL"] = "http://localhost:8080/v1"
+        os.environ["DIEM_FAUCET_URL"] = "http://localhost:8000/mint"
         testnet.JSON_RPC_URL = "http://localhost:8080/v1"
         testnet.FAUCET_URL = "http://localhost:8000/mint"
         testnet.CHAIN_ID = chain_ids.TESTING
+        chain_ids.TESTNET = chain_ids.TESTING

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,10 @@ pylama
 black
 pyre-check
 pytest-cov
+pytest-asyncio==0.14.0
 mypy-protobuf
 pdoc3
 falcon==2.0.0
 waitress
 pygount
+aiohttp==3.7.4.post0

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     package_dir={"": "src"},
     include_package_data=True,  # see MANIFEST.in
     zip_safe=True,
-    install_requires=["requests>=2.20.0", "cryptography>=2.8", "numpy>=1.18", "protobuf>=3.12.4"],
+    install_requires=["requests>=2.20.0", "cryptography>=2.8", "numpy>=1.18", "protobuf>=3.12.4", "aiohttp>=3.7.3"],
     extras_require={
         "all": ["falcon>=2.0.0", "waitress>=1.4.4", "pytest>=6.2.1", "click>=7.1"]
     },

--- a/src/diem/__init__.py
+++ b/src/diem/__init__.py
@@ -3,6 +3,15 @@
 
 """Python client SDK library for the [Diem](https://diem.com) blockchain network."""
 
+from .constants import (
+    ACCOUNT_ADDRESS_LEN,
+    SUB_ADDRESS_LEN,
+    DIEM_HASH_PREFIX,
+    ROOT_ADDRESS,
+    TREASURY_ADDRESS,
+    CORE_CODE_ADDRESS,
+)
+
 from .utils import InvalidAccountAddressError, InvalidSubAddressError
 from .auth_key import AuthKey
 

--- a/src/diem/auth_key.py
+++ b/src/diem/auth_key.py
@@ -5,6 +5,7 @@
 
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 from . import utils, diem_types
+from diem import ACCOUNT_ADDRESS_LEN
 
 
 class AuthKey:
@@ -24,10 +25,10 @@ class AuthKey:
         self.data = data
 
     def account_address(self) -> diem_types.AccountAddress:
-        return utils.account_address(self.data[-utils.ACCOUNT_ADDRESS_LEN :])
+        return utils.account_address(self.data[-ACCOUNT_ADDRESS_LEN:])
 
     def prefix(self) -> bytes:
-        return self.data[: -utils.ACCOUNT_ADDRESS_LEN]
+        return self.data[:-ACCOUNT_ADDRESS_LEN]
 
     def hex(self) -> str:
         return self.data.hex()

--- a/src/diem/constants.py
+++ b/src/diem/constants.py
@@ -1,0 +1,14 @@
+# Copyright (c) The Diem Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Diem constants"""
+
+from diem import diem_types
+
+
+ACCOUNT_ADDRESS_LEN: int = diem_types.AccountAddress.LENGTH
+SUB_ADDRESS_LEN: int = 8
+DIEM_HASH_PREFIX: bytes = b"DIEM::"
+ROOT_ADDRESS: str = "0000000000000000000000000a550c18"
+TREASURY_ADDRESS: str = "0000000000000000000000000b1e55ed"
+CORE_CODE_ADDRESS: str = "00000000000000000000000000000001"

--- a/src/diem/jsonrpc/__init__.py
+++ b/src/diem/jsonrpc/__init__.py
@@ -26,7 +26,8 @@ from .client import (
     Retry,
     RequestStrategy,
     RequestWithBackups,
-    # Exceptions
+)
+from .errors import (
     JsonRpcError,
     NetworkError,
     InvalidServerResponse,
@@ -37,6 +38,7 @@ from .client import (
     WaitForTransactionTimeout,
     AccountNotFoundError,
 )
+from .async_client import AsyncClient
 from .jsonrpc_pb2 import (
     Amount,
     Metadata,

--- a/src/diem/jsonrpc/constants.py
+++ b/src/diem/jsonrpc/constants.py
@@ -13,6 +13,9 @@ See the following Diem JSON-RPC response type documents for more details:
 
 """
 
+from diem.__VERSION__ import VERSION
+
+
 # AccountRole#type field values
 ACCOUNT_ROLE_UNKNOWN: str = "unknown"
 ACCOUNT_ROLE_CHILD_VASP: str = "child_vasp"
@@ -58,3 +61,12 @@ TRANSACTION_DATA_UNKNOWN: str = "unknown"
 # Script#type field values, only set unknown type here,
 # other types, plese see https://github.com/diem/diem/blob/master/language/stdlib/transaction_scripts/doc/transaction_script_documentation.md for all available script names.
 SCRIPT_UNKNOWN: str = "unknown"
+
+
+DEFAULT_CONNECT_TIMEOUT_SECS: float = 5.0
+DEFAULT_TIMEOUT_SECS: float = 30.0
+DEFAULT_MAX_RETRIES: int = 15
+DEFAULT_RETRY_DELAY: float = 0.2
+DEFAULT_WAIT_FOR_TRANSACTION_TIMEOUT_SECS: float = 30.0
+DEFAULT_WAIT_FOR_TRANSACTION_WAIT_DURATION_SECS: float = 0.2
+USER_AGENT_HTTP_HEADER: str = "diem-client-sdk-python / %s" % VERSION

--- a/src/diem/jsonrpc/errors.py
+++ b/src/diem/jsonrpc/errors.py
@@ -1,0 +1,38 @@
+# Copyright (c) The Diem Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+
+class JsonRpcError(Exception):
+    pass
+
+
+class NetworkError(Exception):
+    pass
+
+
+class InvalidServerResponse(Exception):
+    pass
+
+
+class StaleResponseError(Exception):
+    pass
+
+
+class TransactionHashMismatchError(Exception):
+    pass
+
+
+class TransactionExecutionFailed(Exception):
+    pass
+
+
+class TransactionExpired(Exception):
+    pass
+
+
+class WaitForTransactionTimeout(Exception):
+    pass
+
+
+class AccountNotFoundError(ValueError):
+    pass

--- a/src/diem/jsonrpc/state.py
+++ b/src/diem/jsonrpc/state.py
@@ -1,0 +1,11 @@
+# Copyright (c) The Diem Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass
+
+
+@dataclass
+class State:
+    chain_id: int
+    version: int
+    timestamp_usecs: int

--- a/src/diem/testing/__init__.py
+++ b/src/diem/testing/__init__.py
@@ -6,6 +6,19 @@
 1. MiniWallet application as counterparty wallet application stub for testing your wallet application.
 2. Payment test suites provide tests running on top of MiniWallet API for testing wallet application payment features.
 3. `LocalAccount` for managing local account keys and generating random local account.
+4. Testnet Faucet service client
+5. Testnet constants
 """
 
-from .local_account import LocalAccount
+from diem.jsonrpc import AsyncClient
+from diem.testing.constants import FAUCET_URL, JSON_RPC_URL, DD_ADDRESS, XUS
+from diem.testing.faucet import Faucet
+from diem.testing.local_account import LocalAccount
+
+import os
+
+
+def create_client() -> AsyncClient:
+    """Create an `AsyncClient` initialized with Testnet JSON-RPC URL"""
+
+    return AsyncClient(os.getenv("DIEM_JSON_RPC_URL") or JSON_RPC_URL)

--- a/src/diem/testing/constants.py
+++ b/src/diem/testing/constants.py
@@ -1,0 +1,10 @@
+# Copyright (c) The Diem Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Testnet / devnet constants"""
+
+
+JSON_RPC_URL: str = "https://testnet.diem.com/v1"
+FAUCET_URL: str = "https://testnet.diem.com/mint"
+DD_ADDRESS: str = "000000000000000000000000000000dd"
+XUS: str = "XUS"

--- a/src/diem/testing/faucet.py
+++ b/src/diem/testing/faucet.py
@@ -1,0 +1,117 @@
+# Copyright (c) The Diem Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Testnet Faucet service client
+
+```python
+
+from diem import testnet
+from diem.testing import LocalAccount
+
+# create client connects to testnet
+client = testnet.create_client()
+
+# create faucet for minting coins for your testing account
+faucet = testnet.Faucet(client)
+
+# create a local account and mint some coins for it
+account: LocalAccount = faucet.gen_account()
+
+```
+
+"""
+
+import functools, os
+
+from aiohttp import ClientSession
+from diem import diem_types, bcs
+from diem.jsonrpc.async_client import AsyncClient, Retry, TransactionExecutionFailed
+from diem.testing.local_account import LocalAccount
+from diem.testing.constants import FAUCET_URL, XUS
+from typing import Optional, Tuple, Union
+
+
+class Faucet:
+    """Faucet service is a proxy server to mint coins for your test account on Testnet
+
+    See https://github.com/diem/diem/blob/master/json-rpc/docs/service_testnet_faucet.md for more details
+    """
+
+    def __init__(
+        self,
+        client: AsyncClient,
+        url: Union[str, None] = None,
+        retry: Union[Retry, None] = None,
+    ) -> None:
+        self._client: AsyncClient = client
+        self._url: str = url or os.getenv("DIEM_FAUCET_URL") or FAUCET_URL
+        self._retry: Retry = retry or Retry(5, 0.2, Exception)
+
+    async def gen_account(self, currency_code: str = XUS, dd_account: bool = False) -> LocalAccount:
+        account = LocalAccount.generate()
+        await self.mint(account.auth_key.hex(), 100_000_000_000, currency_code, dd_account)
+        return account
+
+    async def gen_vasp(self, currency_code: str = XUS, base_url: str = "") -> Tuple[LocalAccount, LocalAccount]:
+        """Generates a ParentVASP account with a ChildVASP account"""
+
+        parent = await self.gen_account(currency_code)
+        if base_url:
+            await parent.reset_dual_attestation(self._client, base_url)
+        child, payload = parent.new_child_vasp(0, XUS)
+        await parent.apply_txn(self._client, payload)
+
+        return (parent, child)
+
+    async def mint(
+        self,
+        authkey: str,
+        amount: int,
+        currency_code: str,
+        dd_account: bool = False,
+        diem_id_domain: Optional[str] = None,
+        is_remove_domain: bool = False,
+    ) -> None:
+        await self._retry.execute(
+            functools.partial(
+                self._mint_without_retry,
+                authkey,
+                amount,
+                currency_code,
+                dd_account,
+                diem_id_domain,
+                is_remove_domain,
+            )
+        )
+
+    async def _mint_without_retry(
+        self,
+        authkey: str,
+        amount: int,
+        currency_code: str,
+        dd_account: bool = False,
+        diem_id_domain: Optional[str] = None,
+        is_remove_domain: bool = False,
+    ) -> None:
+        params = {
+            "amount": amount,
+            "auth_key": authkey,
+            "currency_code": currency_code,
+            "return_txns": "true",
+            "is_designated_dealer": "true" if dd_account else "false",
+            "is_remove_domain": "true" if is_remove_domain else "false",
+        }
+        if diem_id_domain:
+            params["diem_id_domain"] = diem_id_domain
+        async with ClientSession(raise_for_status=True) as session:
+            async with session.post(self._url, params=params) as response:
+                de = bcs.BcsDeserializer(bytes.fromhex(await response.text()))
+
+        for i in range(de.deserialize_len()):
+            txn = de.deserialize_any(diem_types.SignedTransaction)
+            try:
+                await self._client.wait_for_transaction(txn)
+            except TransactionExecutionFailed as e:
+                if txn.vm_status.explanation.reason == "EDOMAIN_ALREADY_EXISTS":
+                    continue
+                raise e

--- a/src/diem/testnet.py
+++ b/src/diem/testnet.py
@@ -25,14 +25,14 @@ import requests
 import typing
 
 from . import diem_types, jsonrpc, utils, chain_ids, bcs, identifier
-from .testing import LocalAccount
+from .testing import LocalAccount, DD_ADDRESS
 
 
 JSON_RPC_URL: str = "https://testnet.diem.com/v1"
 FAUCET_URL: str = "https://testnet.diem.com/mint"
 CHAIN_ID: diem_types.ChainId = chain_ids.TESTNET
 
-DESIGNATED_DEALER_ADDRESS: diem_types.AccountAddress = utils.account_address("000000000000000000000000000000dd")
+DESIGNATED_DEALER_ADDRESS: diem_types.AccountAddress = utils.account_address(DD_ADDRESS)
 TEST_CURRENCY_CODE: str = "XUS"
 HRP: str = identifier.TDM
 

--- a/src/diem/utils.py
+++ b/src/diem/utils.py
@@ -9,14 +9,10 @@ import hashlib
 import typing, time, socket
 
 from . import diem_types, jsonrpc, stdlib
-
-
-ACCOUNT_ADDRESS_LEN: int = diem_types.AccountAddress.LENGTH
-SUB_ADDRESS_LEN: int = 8
-DIEM_HASH_PREFIX: bytes = b"DIEM::"
-ROOT_ADDRESS: str = "0000000000000000000000000a550c18"
-TREASURY_ADDRESS: str = "0000000000000000000000000b1e55ed"
-CORE_CODE_ADDRESS: str = "00000000000000000000000000000001"
+from .constants import (
+    SUB_ADDRESS_LEN,
+    DIEM_HASH_PREFIX,
+)
 
 
 class InvalidAccountAddressError(Exception):

--- a/tests/jsonrpc/test_async_client.py
+++ b/tests/jsonrpc/test_async_client.py
@@ -1,0 +1,367 @@
+# Copyright (c) The Diem Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+
+from diem import (
+    jsonrpc,
+    diem_types,
+    stdlib,
+    utils,
+    chain_ids,
+    InvalidAccountAddressError,
+    TREASURY_ADDRESS,
+    ROOT_ADDRESS,
+)
+from diem.jsonrpc import AsyncClient
+from diem.testing import LocalAccount, Faucet, create_client, XUS, DD_ADDRESS
+
+import time
+import pytest
+
+
+pytestmark = pytest.mark.asyncio  # pyre-ignore
+
+
+@pytest.fixture
+def client() -> AsyncClient:
+    return create_client()
+
+
+async def test_get_metadata(client: AsyncClient):
+    metadata = await client.get_metadata()
+    assert metadata is not None
+    assert isinstance(metadata, jsonrpc.Metadata)
+    assert metadata.chain_id == chain_ids.TESTNET.value
+    assert metadata.version is not None
+    assert metadata.timestamp is not None
+
+
+async def test_get_metadata_by_version(client: AsyncClient):
+    metadata = await client.get_metadata(1)
+    assert metadata is not None
+    assert isinstance(metadata, jsonrpc.Metadata)
+    assert metadata.chain_id == chain_ids.TESTNET.value
+    assert metadata.version == 1
+    assert metadata.timestamp is not None
+
+    # this is unexpected, will be updated to return None later
+    with pytest.raises(jsonrpc.JsonRpcError):
+        metadata = await client.get_metadata(1999999999999)
+
+
+async def test_get_currencies(client: AsyncClient):
+    currencies = await client.get_currencies()
+    assert currencies is not None
+    assert isinstance(currencies, list)
+    assert len(currencies) > 0
+
+    lbr = next(filter(lambda curr: curr.code == XUS, currencies))
+    assert lbr is not None
+    assert isinstance(lbr, jsonrpc.CurrencyInfo)
+
+
+async def test_get_account(client: AsyncClient):
+    account = await client.get_account(DD_ADDRESS)
+    assert account is not None
+    assert isinstance(account, jsonrpc.Account)
+    assert account.role is not None
+    assert account.role.type == jsonrpc.ACCOUNT_ROLE_DESIGNATED_DEALER
+
+
+async def test_get_account_by_invalid_hex_encoded_account_address(client: AsyncClient):
+    with pytest.raises(InvalidAccountAddressError):
+        await client.get_account(TREASURY_ADDRESS + "invalid")
+
+
+async def test_get_account_not_exist(client: AsyncClient):
+    local_account = LocalAccount.generate()
+    account = await client.get_account(local_account.account_address)
+    assert account is None
+
+
+async def test_get_account_sequence(client: AsyncClient):
+    seq = await client.get_account_sequence(DD_ADDRESS)
+    assert isinstance(seq, int)
+    assert seq > 0
+
+    local = LocalAccount.generate()
+    with pytest.raises(jsonrpc.AccountNotFoundError):
+        await client.get_account_sequence(local.account_address)
+
+
+async def test_get_account_transaction(client: AsyncClient):
+    txn = await client.get_account_transaction(DD_ADDRESS, 0)
+    assert txn is not None
+    assert isinstance(txn, jsonrpc.Transaction)
+    assert txn.version > 0
+    assert txn.hash is not None
+    assert len(txn.events) == 0
+
+
+async def test_get_account_transaction_not_exist(client: AsyncClient):
+    txn = await client.get_account_transaction(ROOT_ADDRESS, 9000000000000000)
+    assert txn is None
+
+
+async def test_get_account_transaction_include_events(client: AsyncClient):
+    faucet = Faucet(client)
+    parent_vasp, _ = await faucet.gen_vasp()
+
+    txn = await client.get_account_transaction(parent_vasp.account_address, 0, include_events=True)
+    assert txn is not None
+    assert isinstance(txn, jsonrpc.Transaction)
+    assert len(txn.events) > 0
+
+
+async def test_get_account_transactions(client: AsyncClient):
+    txns = await client.get_account_transactions(DD_ADDRESS, 0, 1)
+    assert txns is not None
+    assert isinstance(txns, list)
+
+    txn = txns[0]
+    assert isinstance(txn, jsonrpc.Transaction)
+    assert txn.version > 0
+    assert txn.hash is not None
+    assert len(txn.events) == 0
+
+
+async def test_get_account_transactions_not_exist(client: AsyncClient):
+    txn = await client.get_account_transactions(ROOT_ADDRESS, 9000000000000000, 1)
+    assert txn == []
+
+
+async def test_get_account_transactions_with_events(client: AsyncClient):
+    faucet = Faucet(client)
+    parent_vasp, _ = await faucet.gen_vasp()
+
+    txns = await client.get_account_transactions(parent_vasp.account_address, 0, 1, include_events=True)
+    assert txns is not None
+    assert isinstance(txns, list)
+
+    txn = txns[0]
+    assert isinstance(txn, jsonrpc.Transaction)
+    assert len(txn.events) > 0
+
+
+async def test_get_transactions(client: AsyncClient):
+    txns = await client.get_transactions(1, 1)
+    assert txns is not None
+    assert isinstance(txns, list)
+
+    txn = txns[0]
+    assert isinstance(txn, jsonrpc.Transaction)
+    assert txn.version == 1
+    assert txn.hash is not None
+
+
+async def test_get_events(client: AsyncClient):
+    account = await client.get_account(DD_ADDRESS)
+    events = await client.get_events(account.sent_events_key, 0, 1)
+    assert events is not None
+    assert isinstance(events, list)
+
+    event = events[0]
+    assert isinstance(event, jsonrpc.Event)
+    assert event.key == account.sent_events_key
+    assert event.data is not None
+    assert event.data.type == jsonrpc.EVENT_DATA_SENT_PAYMENT
+
+
+async def test_get_state_proof(client: AsyncClient):
+    state_proof = await client.get_state_proof(1)
+    assert state_proof is not None
+    assert isinstance(state_proof, jsonrpc.StateProof)
+    # todo: decode ledger_info and validate version
+
+
+async def test_get_last_known_state(client: AsyncClient):
+    metadata = await client.get_metadata()
+    assert metadata is not None
+    state = client.get_last_known_state()
+    assert state is not None
+
+    assert metadata.chain_id == state.chain_id
+    assert metadata.version == state.version
+    assert metadata.timestamp == state.timestamp_usecs
+
+
+async def test_get_account_state_with_proof(client: AsyncClient):
+    state_proof = await client.get_account_state_with_proof(DD_ADDRESS)
+    assert state_proof is not None
+    assert isinstance(state_proof, jsonrpc.AccountStateWithProof)
+    assert state_proof.version == client.get_last_known_state().version
+
+
+async def test_handle_stale_response_error(client: AsyncClient):
+    last = (await client.get_metadata()).version
+    for i in range(0, 20):
+        metadata = await client.get_metadata()
+        assert metadata.version >= last
+        assert client.get_last_known_state().version == metadata.version
+        last = metadata.version
+
+
+async def test_submit_failed(client: AsyncClient):
+    with pytest.raises(jsonrpc.JsonRpcError):
+        await client.submit("invalid txn")
+
+
+async def test_submit_ignores_stale_resposne_error(client: AsyncClient):
+    account = await Faucet(client).gen_account()
+    script = stdlib.encode_rotate_dual_attestation_info_script(
+        new_url="http://localhost".encode("utf-8"), new_key=account.compliance_public_key_bytes
+    )
+    txn = account.sign(create_transaction(account, script, 0))
+    state = client.get_last_known_state()
+    client._last_known_server_state.version = state.version + 1_000_000_000
+    await client.submit(txn)
+    client._last_known_server_state = state
+    ret = await client.wait_for_transaction(txn)
+    assert ret
+
+
+async def test_wait_for_transaction_hash_mismatched_and_execution_failed(client: AsyncClient):
+    faucet = Faucet(client)
+
+    parent_vasp = await faucet.gen_account()
+    # parent vasp as child, invalid transaction
+    signed_txn = create_child_vasp_txn(parent_vasp, parent_vasp)
+    await client.submit(signed_txn)
+
+    txn = signed_txn.raw_txn
+    with pytest.raises(jsonrpc.TransactionHashMismatchError):
+        await client.wait_for_transaction2(
+            txn.sender, txn.sequence_number, txn.expiration_timestamp_secs, "mismatched hash"
+        )
+
+    with pytest.raises(jsonrpc.TransactionExecutionFailed):
+        await client.wait_for_transaction(signed_txn)
+
+
+async def test_wait_for_transaction_timeout_and_expire(client: AsyncClient):
+    faucet = Faucet(client)
+
+    parent_vasp = await faucet.gen_account()
+
+    with pytest.raises(jsonrpc.TransactionExpired):
+        await client.wait_for_transaction2(parent_vasp.account_address, 1, time.time() + 0.2, "hash")
+
+    with pytest.raises(jsonrpc.WaitForTransactionTimeout):
+        await client.wait_for_transaction2(parent_vasp.account_address, 1, time.time() + 5, "hash", 0.1)
+
+
+async def test_get_parent_vasp_account(client: AsyncClient):
+    faucet = Faucet(client)
+
+    parent_vasp, child_vasp = await faucet.gen_vasp()
+
+    account = await client.get_parent_vasp_account(child_vasp.account_address)
+
+    expected_address = utils.account_address_hex(parent_vasp.account_address)
+    assert account.address == expected_address
+
+    account = await client.get_parent_vasp_account(parent_vasp.account_address)
+    assert account.address == expected_address
+
+
+async def test_get_parent_vasp_account_not_found(client: AsyncClient):
+    parent_vasp = LocalAccount.generate()
+
+    with pytest.raises(jsonrpc.AccountNotFoundError):
+        await client.get_parent_vasp_account(parent_vasp.account_address)
+
+
+async def test_get_parent_vasp_account_with_non_vasp_account_address(client: AsyncClient):
+    with pytest.raises(ValueError):
+        await client.get_parent_vasp_account(TREASURY_ADDRESS)
+
+
+async def test_gen_account(client: AsyncClient):
+    faucet = Faucet(client)
+    vasp = await faucet.gen_account()
+
+    account = await client.get_account(vasp.account_address)
+    assert account.role.type == "parent_vasp"
+
+
+async def test_get_base_url_and_compliance_key(client: AsyncClient):
+    faucet = Faucet(client)
+    parent_vasp, child_vasp = await faucet.gen_vasp(base_url="http://hello.com")
+
+    base_url, key = await client.get_base_url_and_compliance_key(child_vasp.account_address)
+    assert base_url == "http://hello.com"
+    assert utils.public_key_bytes(key) == parent_vasp.compliance_public_key_bytes
+    base_url, key = await client.get_base_url_and_compliance_key(parent_vasp.account_address)
+    assert base_url == "http://hello.com"
+    assert utils.public_key_bytes(key) == parent_vasp.compliance_public_key_bytes
+
+
+async def test_account_not_found_error_when_get_base_url_and_compliance_key_for_invalid_account(client: AsyncClient):
+    account = LocalAccount.generate()
+    with pytest.raises(jsonrpc.AccountNotFoundError):
+        await client.get_base_url_and_compliance_key(account.account_address)
+
+
+async def test_value_error_when_get_base_url_and_compliance_key_for_account_has_no_base_url(client: AsyncClient):
+    with pytest.raises(ValueError):
+        await client.get_base_url_and_compliance_key(TREASURY_ADDRESS)
+
+
+async def test_gen_dd_account(client: AsyncClient):
+    account = await Faucet(client).gen_account(dd_account=True)
+    onchain_account = await client.get_account(account.account_address)
+    assert onchain_account.role.type == "designated_dealer"
+
+
+async def test_init_faucet_with_url(client: AsyncClient):
+    faucet = Faucet(client, "invalid-url")
+    with pytest.raises(ValueError):
+        await faucet.gen_account()
+
+
+async def test_get_diem_id_domain_map(client: AsyncClient):
+    faucet = Faucet(client)
+    parent_vasp1 = await faucet.gen_account()
+    parent_vasp2 = await faucet.gen_account()
+    domain1 = "domain1"
+    domain2 = "domain2"
+
+    await faucet.mint(parent_vasp1.auth_key.hex(), 1, XUS, diem_id_domain=domain1, is_remove_domain=False)
+    await faucet.mint(parent_vasp2.auth_key.hex(), 1, XUS, diem_id_domain=domain2, is_remove_domain=False)
+
+    domain_map = await client.get_diem_id_domain_map()
+    assert domain_map.get(domain1) == parent_vasp1.account_address.to_hex()
+    assert domain_map.get(domain2) == parent_vasp2.account_address.to_hex()
+
+    await faucet.mint(parent_vasp1.auth_key.hex(), 1, XUS, diem_id_domain=domain1, is_remove_domain=True)
+    domain_map = await client.get_diem_id_domain_map()
+    assert domain_map.get(domain1) is None
+
+
+def create_child_vasp_txn(
+    parent_vasp: LocalAccount, child_vasp: LocalAccount, seq: int = 0
+) -> diem_types.RawTransaction:
+    script = stdlib.encode_create_child_vasp_account_script(
+        coin_type=utils.currency_code(XUS),
+        child_address=child_vasp.account_address,
+        auth_key_prefix=child_vasp.auth_key.prefix(),
+        add_all_currencies=False,
+        child_initial_balance=1_000_000,
+    )
+
+    return parent_vasp.sign(create_transaction(parent_vasp, script, seq))
+
+
+def create_transaction(
+    sender: LocalAccount, script: diem_types.Script, seq: int, currency=XUS
+) -> diem_types.RawTransaction:
+    return diem_types.RawTransaction(
+        sender=sender.account_address,
+        sequence_number=seq,
+        payload=diem_types.TransactionPayload__Script(script),
+        max_gas_amount=1_000_000,
+        gas_unit_price=0,
+        gas_currency_code=currency,
+        expiration_timestamp_secs=int(time.time()) + 30,
+        chain_id=chain_ids.TESTNET,
+    )

--- a/tests/test_testnet.py
+++ b/tests/test_testnet.py
@@ -9,6 +9,8 @@ from diem import (
     testnet,
     utils,
     InvalidAccountAddressError,
+    TREASURY_ADDRESS,
+    ROOT_ADDRESS,
 )
 from diem.testing import LocalAccount
 
@@ -63,7 +65,7 @@ def test_get_account():
 
 def test_get_account_by_hex_encoded_account_address():
     client = testnet.create_client()
-    account = client.get_account(utils.TREASURY_ADDRESS)
+    account = client.get_account(TREASURY_ADDRESS)
     assert account is not None
     assert isinstance(account, jsonrpc.Account)
     assert account.role is not None
@@ -73,7 +75,7 @@ def test_get_account_by_hex_encoded_account_address():
 def test_get_account_by_invalid_hex_encoded_account_address():
     client = testnet.create_client()
     with pytest.raises(InvalidAccountAddressError):
-        client.get_account(utils.TREASURY_ADDRESS + "invalid")
+        client.get_account(TREASURY_ADDRESS + "invalid")
 
 
 def test_get_account_not_exist():
@@ -106,7 +108,7 @@ def test_get_account_transaction():
 
 def test_get_account_transaction_not_exist():
     client = testnet.create_client()
-    txn = client.get_account_transaction(utils.ROOT_ADDRESS, 9000000000000000)
+    txn = client.get_account_transaction(ROOT_ADDRESS, 9000000000000000)
     assert txn is None
 
 
@@ -145,7 +147,7 @@ def test_get_account_transactions():
 
 def test_get_account_transactions_not_exist():
     client = testnet.create_client()
-    txn = client.get_account_transactions(utils.ROOT_ADDRESS, 9000000000000000, 1)
+    txn = client.get_account_transactions(ROOT_ADDRESS, 9000000000000000, 1)
     assert txn == []
 
 
@@ -350,7 +352,7 @@ def test_get_parent_vasp_account_with_non_vasp_account_address():
     client = testnet.create_client()
 
     with pytest.raises(ValueError):
-        client.get_parent_vasp_account(utils.TREASURY_ADDRESS)
+        client.get_parent_vasp_account(TREASURY_ADDRESS)
 
 
 def test_gen_account():
@@ -386,7 +388,7 @@ def test_account_not_found_error_when_get_base_url_and_compliance_key_for_invali
 def test_value_error_when_get_base_url_and_compliance_key_for_account_has_no_base_url():
     client = testnet.create_client()
     with pytest.raises(ValueError):
-        client.get_base_url_and_compliance_key(utils.TREASURY_ADDRESS)
+        client.get_base_url_and_compliance_key(TREASURY_ADDRESS)
 
 
 def test_gen_dd_account():


### PR DESCRIPTION
Start to migrate to async client.
Created new async Faucet client inside testing package, and moved some testnet consts into testing package as well.

For moving away from configuring testnet and faucet clients by updating testnet module JSON_RPC_URL and testnet.FAUCET_URL variables, start to accepts environment variables "DIEM_JSON_RPC_URL" and "DIEM_FAUCET_URL" to setup testnet and faucet server urls for new clients.

Extract out couple new small modules in jsonrpc for sharing constants, error classes and State class between blocking client and async client.

See #313 for more details.