### PR TITLE
Refactoring mini-wallet send payment transaction logic

### DIFF
--- a/src/diem/testing/miniwallet/app/json_input.py
+++ b/src/diem/testing/miniwallet/app/json_input.py
@@ -13,18 +13,18 @@ Validator = Callable[[str, T], Awaitable[None]]
 class JsonInput:
     data: Dict[str, Any]
 
-    async def get_nullable(self, name: str, typ: Type[T], validator: Optional[Validator] = None) -> Optional[T]:
+    async def get_nullable(self, name: str, klass: Type[T], validator: Optional[Validator] = None) -> Optional[T]:
         val = self.data.get(name, None)
         if val is None:
             return None
-        if isinstance(val, typ):
+        if isinstance(val, klass):
             if validator:
                 await validator(name, val)
             return val
-        raise ValueError("%r type must be %r, but got %r" % (name, typ.__name__, type(val).__name__))
+        raise ValueError("%r type must be %r, but got %r" % (name, klass.__name__, type(val).__name__))
 
-    async def get(self, name: str, typ: Type[T], validator: Optional[Validator] = None) -> T:
-        val = await self.get_nullable(name, typ, validator)
+    async def get(self, name: str, klass: Type[T], validator: Optional[Validator] = None) -> T:
+        val = await self.get_nullable(name, klass, validator)
         if val is None:
             raise ValueError("%r is required" % name)
         return val

--- a/src/diem/testing/miniwallet/app/models.py
+++ b/src/diem/testing/miniwallet/app/models.py
@@ -4,7 +4,7 @@
 from dataclasses import dataclass, field, asdict, fields
 from enum import Enum
 from typing import Optional, List, Dict, Any
-from .... import offchain, diem_types, identifier
+from .... import offchain, diem_types
 import json
 
 
@@ -99,7 +99,8 @@ class Transaction(Base):
     diem_transaction_version: Optional[int] = field(default=None)
     refund_diem_txn_version: Optional[int] = field(default=None)
     refund_reason: Optional[RefundReason] = field(default=None)
-    payee_onchain_address: Optional[str] = field(default=None)
+    payee_account_identifier: Optional[str] = field(default=None)
+    payee_account_id: Optional[str] = field(default=None)
 
     def subaddress(self) -> bytes:
         return bytes.fromhex(str(self.subaddress_hex))
@@ -109,9 +110,6 @@ class Transaction(Base):
 
     def __str__(self) -> str:
         return "Transaction %s" % json.dumps(asdict(self), indent=2)
-
-    def payee_account_identifier(self, hrp: str) -> str:
-        return identifier.encode_account(str(self.payee_onchain_address), None, hrp)
 
 
 @dataclass

--- a/tests/miniwallet/test_diem_account.py
+++ b/tests/miniwallet/test_diem_account.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from diem import diem_types
 from diem.testing import LocalAccount, create_client, Faucet, XUS
 from diem.testing.miniwallet.app import Transaction
 from diem.testing.miniwallet.app.diem_account import DiemAccount
@@ -21,8 +20,7 @@ async def test_no_child_accounts():
     assert da.account_identifier() == account.account_identifier()
 
     payee = await faucet.gen_account()
-    signed_txn_hex = await da.submit_p2p(gen_txn(payee=payee.account_identifier()), (b"", b""))
-    signed_txn = diem_types.SignedTransaction.bcs_deserialize(bytes.fromhex(signed_txn_hex))
+    signed_txn = await da.submit_p2p(gen_txn(payee=payee.account_identifier()), (b"", b""))
     assert signed_txn.raw_txn.sender == account.account_address
 
 
@@ -58,4 +56,5 @@ def gen_txn(payee: str, amount: int = 1) -> Transaction:
         status=Transaction.Status.pending,
         type=Transaction.Type.sent_payment,
         payee=payee,
+        payee_account_identifier=payee,
     )


### PR DESCRIPTION
1. Move exchanging diem id with receiver address logic into create_account_payment method, so that invalid diem_id will fail early when the api is called instead of raising error and cancel transaction in background.
2. Unify the way we send payment to internal account by looking up payee account id when creating the payment transaction
3. Unify the way we send payment transaction to external account by looking up payee account identifier (init after diem id exchange)
4. Remove thread lock in store class, asyncio code runs in one thread.