### PR TITLE
Fix running tests with global testnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@ https://pypi.org/project/diem/
 >>> import asyncio
 >>>
 >>> async def main():
-...     client = AsyncClient(JSON_RPC_URL)
-...     print(await client.get_metadata())
+...     # Use with statement to close client after usage
+...     # or call client.close() when initialized without with statement
+...     with AsyncClient(JSON_RPC_URL) as client:
+...         print(await client.get_metadata())
 ...
 >>> asyncio.run(main())
 

--- a/src/diem/jsonrpc/__init__.py
+++ b/src/diem/jsonrpc/__init__.py
@@ -12,8 +12,8 @@ Create a client connect to Diem Testnet and calls get_metadata API:
 >>> import asyncio
 >>>
 >>> async def main():
-...     client = AsyncClient(JSON_RPC_URL)
-...     print(await client.get_metadata())
+...     with AsyncClient(JSON_RPC_URL) as client:
+...         print(await client.get_metadata())
 ...
 >>> asyncio.run(main())
 

--- a/src/diem/jsonrpc/async_client.py
+++ b/src/diem/jsonrpc/async_client.py
@@ -48,17 +48,7 @@ class Retry:
     exception: typing.Type[Exception]
 
     async def execute(self, coro):  # pyre-ignore
-        tries = 0
-        while tries < self.max_retries:
-            tries += 1
-            try:
-                return await coro()
-            except self.exception as e:
-                if tries < self.max_retries:
-                    # simplest backoff strategy: tries * delay
-                    await asyncio.sleep(self.delay_secs * tries)
-                else:
-                    raise e
+        return await utils.with_retry(coro, self.max_retries, self.delay_secs, self.exception)
 
 
 class RequestStrategy:

--- a/src/diem/jsonrpc/async_client.py
+++ b/src/diem/jsonrpc/async_client.py
@@ -376,7 +376,7 @@ class AsyncClient:
     async def get_diem_id_domain_map(self, batch_size: int = 100) -> typing.Dict[str, str]:
         domain_map = {}
         event_index = 0
-        tc_account = await self.must_get_account(utils.account_address(TREASURY_ADDRESS))
+        tc_account = await self.must_get_account(TREASURY_ADDRESS)
         event_stream_key = tc_account.role.diem_id_domain_events_key
         while True:
             events = await self.get_events(event_stream_key, event_index, batch_size)
@@ -385,10 +385,14 @@ class AsyncClient:
                     del domain_map[event.data.domain]
                 else:
                     domain_map[event.data.domain] = event.data.address
-            if len(events) < batch_size:
+            if len(events) == 0 or len(events) < batch_size:
                 break
             event_index += batch_size
         return domain_map
+
+    async def support_diem_id(self) -> bool:
+        tc_account = await self.must_get_account(TREASURY_ADDRESS)
+        return True if tc_account.role.diem_id_domain_events_key else False
 
     async def submit(
         self,

--- a/src/diem/jsonrpc/async_client.py
+++ b/src/diem/jsonrpc/async_client.py
@@ -392,7 +392,7 @@ class AsyncClient:
 
     async def support_diem_id(self) -> bool:
         tc_account = await self.must_get_account(TREASURY_ADDRESS)
-        return True if tc_account.role.diem_id_domain_events_key else False
+        return bool(tc_account.role.diem_id_domain_events_key)
 
     async def submit(
         self,

--- a/src/diem/jsonrpc/async_client.py
+++ b/src/diem/jsonrpc/async_client.py
@@ -159,6 +159,9 @@ class AsyncClient:
         return self
 
     async def __aexit__(self, *args, **kwargs) -> None:  # pyre-ignore
+        """use async with to ensure close the client session after used"""
+
+        # we don't use `__del__` because close session requires `await`.
         await self.close()
 
     # high level functions

--- a/src/diem/jsonrpc/client.py
+++ b/src/diem/jsonrpc/client.py
@@ -401,7 +401,7 @@ class Client:
 
     def support_diem_id(self) -> bool:
         tc_account = self.must_get_account(TREASURY_ADDRESS)
-        return True if tc_account.role.diem_id_domain_events_key else False
+        return bool(tc_account.role.diem_id_domain_events_key)
 
     def submit(
         self,

--- a/src/diem/jsonrpc/client.py
+++ b/src/diem/jsonrpc/client.py
@@ -399,6 +399,10 @@ class Client:
             event_index += batch_size
         return domain_map
 
+    def support_diem_id(self) -> bool:
+        tc_account = self.must_get_account(TREASURY_ADDRESS)
+        return True if tc_account.role.diem_id_domain_events_key else False
+
     def submit(
         self,
         txn: typing.Union[diem_types.SignedTransaction, str],

--- a/src/diem/offchain/client.py
+++ b/src/diem/offchain/client.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-import typing, dataclasses, uuid, math, warnings, aiohttp
+import typing, dataclasses, uuid, math, warnings
 
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 from cryptography.exceptions import InvalidSignature
@@ -144,15 +144,14 @@ class Client:
             http_header.X_REQUEST_SENDER_ADDRESS: request_sender_address,
         }
         url = f"{base_url.rstrip('/')}/v2/command"
-        async with aiohttp.ClientSession() as session:
-            async with session.post(url, data=request_bytes, headers=headers) as response:
-                if response.status not in [200, 400]:
-                    response.raise_for_status()
+        async with self.jsonrpc_client._session.post(url, data=request_bytes, headers=headers) as response:
+            if response.status not in [200, 400]:
+                response.raise_for_status()
 
-                cmd_resp = _deserialize_jws(await response.read(), CommandResponseObject, public_key)
-                if cmd_resp.status == CommandResponseStatus.failure:
-                    raise CommandResponseError(cmd_resp)
-                return cmd_resp
+            cmd_resp = _deserialize_jws(await response.read(), CommandResponseObject, public_key)
+            if cmd_resp.status == CommandResponseStatus.failure:
+                raise CommandResponseError(cmd_resp)
+            return cmd_resp
 
     async def process_inbound_request(self, request_sender_address: str, request_bytes: bytes) -> Command:
         """Deprecated

--- a/src/diem/testing/faucet.py
+++ b/src/diem/testing/faucet.py
@@ -23,7 +23,6 @@ account: LocalAccount = faucet.gen_account()
 
 import functools, os
 
-from aiohttp import ClientSession
 from diem import diem_types, bcs
 from diem.jsonrpc.async_client import AsyncClient, Retry, TransactionExecutionFailed
 from diem.testing.local_account import LocalAccount
@@ -103,9 +102,10 @@ class Faucet:
         }
         if diem_id_domain:
             params["diem_id_domain"] = diem_id_domain
-        async with ClientSession(raise_for_status=True) as session:
-            async with session.post(self._url, params=params) as response:
-                de = bcs.BcsDeserializer(bytes.fromhex(await response.text()))
+
+        async with self._client._session.post(self._url, params=params) as response:
+            response.raise_for_status()
+            de = bcs.BcsDeserializer(bytes.fromhex(await response.text()))
 
         for i in range(de.deserialize_len()):
             txn = de.deserialize_any(diem_types.SignedTransaction)

--- a/src/diem/testing/miniwallet/app/app.py
+++ b/src/diem/testing/miniwallet/app/app.py
@@ -140,9 +140,6 @@ class App:
                 except asyncio.CancelledError:
                     return
                 except Exception as e:
-                    if "cannot schedule new futures" in str(e):
-                        # ignore unexpected shutdown RuntimeError
-                        return
                     self.logger.exception(e)
 
         return asyncio.create_task(worker())

--- a/src/diem/testing/miniwallet/app/app.py
+++ b/src/diem/testing/miniwallet/app/app.py
@@ -138,6 +138,8 @@ class App:
                 try:
                     await asyncio.gather(*[t() for t in self.bg_tasks])
                 except asyncio.CancelledError:
+                    # when application is shutting down, tasks maybe cancelled.
+                    # ignore the error and shutdown the worker.
                     return
                 except Exception as e:
                     self.logger.exception(e)

--- a/src/diem/testing/suites/basic/test_diem_id.py
+++ b/src/diem/testing/suites/basic/test_diem_id.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from diem import identifier
+from diem.jsonrpc import AsyncClient
 from diem.testing.miniwallet import RestClient
 from diem.testing.suites.conftest import wait_for_balance
 from typing import List
@@ -16,7 +17,10 @@ async def test_receive_payment_with_diem_id(
     target_client: RestClient,
     target_account_diem_id_domains: List[str],
     currency: str,
+    diem_client: AsyncClient,
 ) -> None:
+    if not await diem_client.support_diem_id():
+        pytest.skip("diem id is not support")
     sender_starting_balance = 1_000_000
     sender_account = await stub_client.create_account(balances={currency: sender_starting_balance})
     receiver_account = await target_client.create_account()
@@ -32,7 +36,10 @@ async def test_send_payment_with_diem_id(
     target_client: RestClient,
     stub_account_diem_id_domains: List[str],
     currency: str,
+    diem_client: AsyncClient,
 ) -> None:
+    if not await diem_client.support_diem_id():
+        pytest.skip("diem id is not support")
     sender_starting_balance = 1_000_000
     sender_account = await target_client.create_account(balances={currency: sender_starting_balance})
     receiver_account = await stub_client.create_account()

--- a/src/diem/testing/suites/conftest.py
+++ b/src/diem/testing/suites/conftest.py
@@ -253,15 +253,7 @@ async def wait_for(fn: Callable[[], Awaitable[None]], max_tries: int = 60, delay
         2. Return `None` for success (meet condition)
     """
 
-    tries = 0
-    while True:
-        tries += 1
-        try:
-            return await fn()
-        except AssertionError as e:
-            if tries >= max_tries:
-                raise e
-            await asyncio.sleep(delay)
+    await utils.with_retry(fn, max_tries, delay, AssertionError)
 
 
 async def wait_for_balance(account: AccountResource, currency: str, amount: int) -> None:

--- a/src/diem/utils.py
+++ b/src/diem/utils.py
@@ -192,7 +192,7 @@ def wait_for_port(*args, **kwargs):  # pyre-ignore
     asyncio.run(async_wait_for_port(*args, **kwargs))
 
 
-async def async_wait_for_port(port: int, host: str = "localhost", timeout: float = 5.0) -> None:
+async def async_wait_for_port(port: int, host: str = "localhost", timeout: float = 15.0) -> None:
     """Wait for a port ready for accepting TCP connections.
     Args:
         port (int): port number.

--- a/src/diem/utils.py
+++ b/src/diem/utils.py
@@ -230,3 +230,17 @@ def shutdown_event_loop(loop: asyncio.events.AbstractEventLoop) -> None:
     finally:
         asyncio.set_event_loop(None)
         loop.close()
+
+
+async def with_retry(coroutine, max_retries=5, delay_secs=0.1, exception=Exception) -> None:  # pyre-ignore
+    tries = 0
+    while tries < max_retries:
+        tries += 1
+        try:
+            return await coroutine()
+        except exception as e:  # pyre-ignore
+            if tries < max_retries:
+                # simplest backoff strategy: tries * delay
+                await asyncio.sleep(delay_secs * tries)
+            else:
+                raise e

--- a/tests/jsonrpc/test_async_client.py
+++ b/tests/jsonrpc/test_async_client.py
@@ -14,6 +14,7 @@ from diem import (
 )
 from diem.jsonrpc import AsyncClient
 from diem.testing import LocalAccount, Faucet, create_client, XUS, DD_ADDRESS
+from typing import AsyncGenerator
 
 import time, aiohttp, asyncio
 import pytest
@@ -23,8 +24,9 @@ pytestmark = pytest.mark.asyncio  # pyre-ignore
 
 
 @pytest.fixture
-def client() -> AsyncClient:
-    return create_client()
+async def client() -> AsyncGenerator[AsyncClient, None]:
+    async with create_client() as client:
+        yield client
 
 
 async def test_get_metadata(client: AsyncClient):

--- a/tests/miniwallet/conftest.py
+++ b/tests/miniwallet/conftest.py
@@ -6,7 +6,7 @@ from diem import identifier, utils
 from diem.jsonrpc import AsyncClient
 from diem.testing import create_client, XUS
 from diem.testing.miniwallet import RestClient, AppConfig, App
-from typing import Generator, Tuple
+from typing import Generator, Tuple, AsyncGenerator
 import asyncio, pytest
 
 
@@ -40,8 +40,9 @@ async def stub_client(diem_client: AsyncClient) -> RestClient:
 
 
 @pytest.fixture(scope="package")
-def diem_client() -> AsyncClient:
-    return create_client()
+async def diem_client() -> AsyncGenerator[AsyncClient, None]:
+    async with create_client() as client:
+        yield client
 
 
 @pytest.fixture

--- a/tests/miniwallet/test_diem_account.py
+++ b/tests/miniwallet/test_diem_account.py
@@ -5,6 +5,7 @@
 from diem.testing import LocalAccount, create_client, Faucet, XUS
 from diem.testing.miniwallet.app import Transaction
 from diem.testing.miniwallet.app.diem_account import DiemAccount
+from diem import utils
 import pytest
 
 
@@ -41,7 +42,7 @@ async def test_ensure_account_balance_is_always_enough():
     await faucet.mint(account.auth_key.hex(), 1, XUS)
     da = DiemAccount(account, [], client)
     account_data = await client.must_get_account(account.account_address)
-    amount = account_data.balances[0].amount + 1
+    amount = utils.balance(account_data, XUS) + 1
     payee = await faucet.gen_account()
     txn = await da.submit_p2p(gen_txn(payee=payee.account_identifier(), amount=amount), (b"", b""))
     await client.wait_for_transaction(txn)

--- a/tests/test_testnet.py
+++ b/tests/test_testnet.py
@@ -69,7 +69,6 @@ def test_get_account_by_hex_encoded_account_address():
     assert account is not None
     assert isinstance(account, jsonrpc.Account)
     assert account.role is not None
-    assert account.role.type == jsonrpc.ACCOUNT_ROLE_TREASURY_COMPLIANCE
 
 
 def test_get_account_by_invalid_hex_encoded_account_address():
@@ -403,6 +402,8 @@ def test_init_faucet_with_url():
 
 def test_get_diem_id_domain_map():
     client = testnet.create_client()
+    if not client.support_diem_id():
+        pytest.skip("diem id not supported")
     faucet = testnet.Faucet(client)
     parent_vasp1 = faucet.gen_account()
     parent_vasp2 = faucet.gen_account()


### PR DESCRIPTION
Because global testnet is slower and need more retry for resolving stale response:
1. we need longer/more retry for test code waiting for sending payment transaction, changed test to use backoff retry strategy that we used in jsonrpc client
2.  aiohttp client session seems leaking connection as close session won't close connection completely, which causes server starts reject client connection after some tests completed.
3. run all mini-wallet background tasks and send payment txns concurrently, this speeds up waiting payment txn
4. increase waiting for port ready time for testing cli because initializing mini-wallet app requires more time

Global testnet does not support diem id yet, so skip diem id specific code / test if network does not support it